### PR TITLE
chore: restore demo data load on startup

### DIFF
--- a/backend/api/fixtures/demo.json
+++ b/backend/api/fixtures/demo.json
@@ -1,0 +1,141 @@
+[
+    {
+        "model": "api.AreaGroup",
+        "pk": 2,
+        "fields": {
+          "group_name": "Basement",
+          "group_order": 1,
+          "group_color": "area1"
+        }
+    },
+    {
+        "model": "api.AreaGroup",
+        "pk": 3,
+        "fields": {
+          "group_name": "1st Floor",
+          "group_order": 2,
+          "group_color": "area2"
+        }
+    },
+    {
+        "model": "api.AreaGroup",
+        "pk": 4,
+        "fields": {
+          "group_name": "2nd Floor",
+          "group_order": 3,
+          "group_color": "area3"
+        }
+    },
+    {
+      "model": "api.Area",
+      "pk": 1,
+      "fields": {
+        "area_name": "Kitchen",
+        "area_icon": "mdi-fridge",
+        "group": 3,
+        "area_order": 1
+      }
+    },
+    {
+        "model": "api.Area",
+        "pk": 2,
+        "fields": {
+          "area_name": "Living Room",
+          "area_icon": "mdi-sofa",
+          "group": 3,
+          "area_order": 2
+        }
+    },
+    {
+        "model": "api.Area",
+        "pk": 3,
+        "fields": {
+          "area_name": "Laundry Room",
+          "area_icon": "mdi-washing-machine",
+          "group": 2,
+          "area_order": 1
+        }
+    },
+    {
+        "model": "api.Area",
+        "pk": 4,
+        "fields": {
+          "area_name": "Bedroom",
+          "area_icon": "mdi-bed",
+          "group": 4,
+          "area_order": 1
+        }
+    },
+    {
+        "model": "api.Chore",
+        "pk": 1,
+        "fields": {
+          "chore_name": "Dust",
+          "area": 4,
+          "nextDue": "2025-08-01",
+          "lastCompleted": "2025-07-01",
+          "intervalNumber": 1,
+          "unit": "month(s)",
+          "active_months": [1,2,3,4,5,6,7,8,9,10,11,12],
+          "assignee": null,
+          "effort": 1,
+          "vacationPause": 0,
+          "expand": false,
+          "status": 0
+        }
+    },
+    {
+        "model": "api.Chore",
+        "pk": 2,
+        "fields": {
+          "chore_name": "Sweep floor",
+          "area": 3,
+          "nextDue": "2025-07-01",
+          "lastCompleted": "2025-06-01",
+          "intervalNumber": 1,
+          "unit": "month(s)",
+          "active_months": [1,2,3,4,5,6,7,8,9,10,11,12],
+          "assignee": null,
+          "effort": 1,
+          "vacationPause": 0,
+          "expand": false,
+          "status": 0
+        }
+    },
+    {
+        "model": "api.Chore",
+        "pk": 3,
+        "fields": {
+          "chore_name": "Vacuum rug",
+          "area": 2,
+          "nextDue": "2025-06-28",
+          "lastCompleted": "2025-06-21",
+          "intervalNumber": 1,
+          "unit": "week(s)",
+          "active_months": [1,2,3,4,5,6,7,8,9,10,11,12],
+          "assignee": null,
+          "effort": 1,
+          "vacationPause": 0,
+          "expand": false,
+          "status": 0
+        }
+    },
+    {
+        "model": "api.Chore",
+        "pk": 4,
+        "fields": {
+          "chore_name": "Empty trash",
+          "area": 1,
+          "nextDue": "2025-07-05",
+          "lastCompleted": "2025-07-02",
+          "intervalNumber": 3,
+          "unit": "day(s)",
+          "active_months": [1,2,3,4,5,6,7,8,9,10,11,12],
+          "assignee": null,
+          "effort": 1,
+          "vacationPause": 0,
+          "expand": false,
+          "status": 0
+        }
+    }
+]

--- a/backend/api/management/commands/loaddemodata.py
+++ b/backend/api/management/commands/loaddemodata.py
@@ -1,0 +1,23 @@
+# yourapp/management/commands/load_demo_data.py
+
+from django.core.management.base import BaseCommand
+from django.core.management import call_command
+from api.models import (
+    Area,
+)
+
+
+class Command(BaseCommand):
+    help = "Load demo fixtures if this is the first time the app is run"
+
+    def handle(self, *args, **options):
+        if Area.objects.exists():
+            self.stdout.write(
+                self.style.NOTICE(
+                    "Skipping demo fixtures: data already exists."
+                )
+            )
+        else:
+            self.stdout.write("Loading demo data...")
+            call_command("loaddata", "demo.json")
+            self.stdout.write(self.style.SUCCESS("Demo data loaded."))

--- a/backend/start.dev.sh
+++ b/backend/start.dev.sh
@@ -18,5 +18,6 @@ python manage.py loaddata month
 python manage.py loaddata usergroups
 python manage.py loaddata version
 python manage.py scheduletasks
+python manage.py loaddemodata
 mkdocs serve --config-file mkdocs.yml --dev-addr=0.0.0.0:8002 &
 python manage.py runserver 0.0.0.0:8001

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -18,4 +18,5 @@ python manage.py loaddata month
 python manage.py loaddata usergroups
 python manage.py loaddata version
 python manage.py scheduletasks
+python manage.py loaddemodata
 gunicorn backend.wsgi:application --bind 0.0.0.0:8000


### PR DESCRIPTION
## Summary
- Restores the `loaddemodata` management command call in `start.dev.sh` that was dropped during the semantic-release CI migration (originally merged in PR #6)
- Also preserves the mkdocs-in-background fix from the allauth migration

## Test plan
- [ ] Verify demo data loads correctly on container startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)