### PR TITLE
chore: add .claude/settings.local.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.DS_Store
+.claude/settings.local.json
 static
 staticfiles
 media


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.local.json` to `.gitignore` — this file contains personal Claude Code hook config (linting) and should not be committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)