### PR TITLE
fix: remove excess blank lines in api.py (E303)

### DIFF
--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -40,7 +40,6 @@ class VersionOut(Schema):
     version_number: str
 
 
-
 class LoginUserSchema(Schema):
     """
     Schema to represent a LoginUserSchema.
@@ -1362,7 +1361,6 @@ def delete_historyitem(request, historyitem_id: int):
     historyitem = get_object_or_404(HistoryItem, id=historyitem_id)
     historyitem.delete()
     return {"success": True}
-
 
 
 @api.get("/version/list", response=VersionOut, auth=None)


### PR DESCRIPTION
## Summary
- Fixes two E303 (too many blank lines) violations in `backend/backend/api.py` at lines 44 and 1368
- These violations caused the Docker build CI to fail at the flake8 lint step
- Matches the ignore rules used in the Dockerfile: `--ignore=E501,F401`

## Test plan
- [ ] Verify Docker build CI passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)