### PR TITLE
fix: dynamically read frontend version from package.json

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -46,6 +46,7 @@ import { useVersion } from "@/composables/versionComposable";
 import { useQueryClient } from "@tanstack/vue-query";
 import { useRouter } from "vue-router";
 import axios from "axios";
+import { version as appVersion } from "../package.json";
 
 const reloadPage = () => {
   window.location.reload();
@@ -58,7 +59,7 @@ const { prefetchVersion, version } = useVersion();
 const showBanner = ref(false);
 
 const checkVersion = computed(() => {
-  return version.value && version.value.version_number !== "1.3.0-rc.1";
+  return version.value && version.value.version_number !== appVersion;
 });
 
 const updateBanner = () => {

--- a/frontend/src/views/AppNavigation.vue
+++ b/frontend/src/views/AppNavigation.vue
@@ -25,7 +25,7 @@
       </v-list>
     </v-menu>
     <v-img :width="208" aspect-ratio="1/1" src="logov2.png" inline></v-img>
-    <span class="text-subtitle-2 font-italic text-grey-darken-1">v1.3.0-rc.1</span>
+    <span class="text-subtitle-2 font-italic text-grey-darken-1">v{{ appVersion }}</span>
     <v-spacer></v-spacer>
     <v-menu
       v-model="menu"
@@ -74,6 +74,7 @@
   import AddAreaGroupForm from "@/components/AddAreaGroupForm.vue";
   import { useOptions } from "@/composables/optionsComposable";
   import VacationForm from "@/components/VacationForm.vue";
+  import { version as appVersion } from "../../package.json";
 
   const { options } = useOptions();
   const showVacationForm = ref(false);


### PR DESCRIPTION
## Summary
- Replace hardcoded `1.3.0-rc.1` version strings in `App.vue` and `AppNavigation.vue` with a dynamic import from `package.json`
- Version display in navbar now stays current after each semantic-release bump
- Update-available banner no longer falsely triggers after deploys

## Test plan
- [ ] Navbar shows correct version (currently `v1.3.0-rc.3`)
- [ ] "Update available" banner does not appear on fresh load when frontend and backend are on the same version

🤖 Generated with [Claude Code](https://claude.com/claude-code)