### PR TITLE
fix: always fetch allauth session on mount to initialize CSRF cookie

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -67,11 +67,10 @@ const updateBanner = () => {
 };
 
 const checkSession = async () => {
-  if (!userstore.isLoggedIn) return;
   try {
     await axios.get("/_allauth/browser/v1/auth/session");
   } catch (error) {
-    if (error.response && error.response.status === 401) {
+    if (error.response && error.response.status === 401 && userstore.isLoggedIn) {
       userstore.logoutUser();
       router.push("/login");
     }


### PR DESCRIPTION
## Summary
- `checkSession()` previously returned early when the user was not logged in, so the `csrftoken` cookie was never set for unauthenticated visitors
- Login POST was then rejected with `403 CSRF cookie not set`
- Fix: always call `/_allauth/browser/v1/auth/session` on mount; only redirect to `/login` on 401 if the user *was* previously authenticated (expired session handling is preserved)

## Root cause
The `if (!userstore.isLoggedIn) return` guard blocked the HTTP call entirely, so Django never had a chance to set the CSRF cookie in the response. The allauth session endpoint sets the cookie regardless of auth state.

## Test plan
- [ ] Fresh browser session (no cookies) can log in without 403
- [ ] Expired session still redirects to `/login` correctly
- [ ] Normal authenticated usage unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)