### PR TITLE
feat: add Redis caching with write-through invalidation

### DIFF
--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -19,6 +19,20 @@ from django.db.models import Count, F
 from django.utils import timezone
 from django.db.models.functions import TruncDate
 from django.core.paginator import Paginator
+from django.core.cache import cache
+
+CACHE_TTL = 15 * 60  # 15 minutes
+
+
+def invalidate(*keys):
+    """Delete one or more exact cache keys."""
+    cache.delete_many(keys)
+
+
+def invalidate_pattern(*patterns):
+    """Delete all cache keys matching the given patterns (requires django-redis)."""
+    for pattern in patterns:
+        cache.delete_pattern(pattern)
 
 api = NinjaAPI(auth=django_auth, csrf=True, urls_namespace="api_v2")
 router = Router()
@@ -498,6 +512,11 @@ def get_weeklytotals(request, week: Optional[int] = 0):
     Returns:
         (GraphData): The graph data with labels and datasets.
     """
+    cache_key = f"weeklytotals:{week}"
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
     labels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
     today = timezone.now().date()
     days = week * 7
@@ -558,6 +577,7 @@ def get_weeklytotals(request, week: Optional[int] = 0):
         start_of_week.strftime("%m/%d") + " to " + end_of_week.strftime("%m/%d")
     )
     graph = GraphData(labels=labels, datasets=datasets, title=title)
+    cache.set(cache_key, graph, CACHE_TTL)
     return graph
 
 
@@ -616,6 +636,8 @@ def toggle_vacation(request):
             chore.status = 0
             chore.nextDue = date.today() + timedelta(days=chore.vacationPause)
             chore.save()
+    invalidate("options")
+    invalidate_pattern("chores:*")
     return {"success": True}
 
 
@@ -636,6 +658,7 @@ def create_areagroup(request, payload: AreaGroupIn):
         (int): The ID of the newly created AreaGroup object.
     """
     areagroup = AreaGroup.objects.create(**payload.dict())
+    invalidate("areagroups")
     return {"id": areagroup.id}
 
 
@@ -656,6 +679,7 @@ def create_area(request, payload: AreaIn):
         (int): ID of the newly created Area object.
     """
     area = Area.objects.create(**payload.dict())
+    invalidate("areas", "areagroups")
     return {"id": area.id}
 
 
@@ -690,6 +714,7 @@ def create_chore(request, payload: ChoreIn):
     # Set the active_months field
     chore.active_months.set(active_months)
 
+    invalidate_pattern("chores:*")
     return {"id": chore.id}
 
 
@@ -716,6 +741,7 @@ def create_historyitem(request, payload: HistoryItemIn):
         completed_by=completed_by_object,
         chore_id=payload.chore_id,
     )
+    invalidate_pattern("chores:*", "weeklytotals:*")
     return {"id": historyitem.id}
 
 
@@ -834,7 +860,11 @@ def list_areagroups(request):
     Returns:
         (List[AreaGroupOut]): List of AreaGroup objects.
     """
-    qs = AreaGroup.objects.all()
+    cached = cache.get("areagroups")
+    if cached is not None:
+        return cached
+    qs = list(AreaGroup.objects.all())
+    cache.set("areagroups", qs, CACHE_TTL)
     return qs
 
 
@@ -853,7 +883,11 @@ def list_areas(request):
     Returns:
         (List[AreaOut]): List of Area objects.
     """
-    qs = Area.objects.all().order_by("group__group_order", "area_name")
+    cached = cache.get("areas")
+    if cached is not None:
+        return cached
+    qs = list(Area.objects.all().order_by("group__group_order", "area_name"))
+    cache.set("areas", qs, CACHE_TTL)
     return qs
 
 
@@ -882,6 +916,11 @@ def list_chores(
     Returns:
         (List[ChoreOut]): List of Chore objects.
     """
+    cache_key = f"chores:{inactive}:{timeframe}:{assignee_id}:{area_id}"
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
     qs = Chore.objects.all().order_by(
         "status", "nextDue", "lastCompleted", "effort", "chore_name", "id"
     )
@@ -939,6 +978,7 @@ def list_chores(
         )
         chore_list.append(chore_data)
 
+    cache.set(cache_key, chore_list, CACHE_TTL)
     return chore_list
 
 
@@ -1010,7 +1050,11 @@ def list_options(request):
     Returns:
         (List[OptionOut]): List of Option objects.
     """
-    qs = Option.objects.all()
+    cached = cache.get("options")
+    if cached is not None:
+        return cached
+    qs = list(Option.objects.all())
+    cache.set("options", qs, CACHE_TTL)
     return qs
 
 
@@ -1029,7 +1073,11 @@ def list_users(request):
     Returns:
         (List[CustomUserSchema]): List of CustomUser objects.
     """
-    qs = CustomUser.objects.all()
+    cached = cache.get("users")
+    if cached is not None:
+        return cached
+    qs = list(CustomUser.objects.all())
+    cache.set("users", qs, CACHE_TTL)
     return qs
 
 
@@ -1055,6 +1103,7 @@ def update_areagroup(request, areagroup_id: int, payload: AreaGroupIn):
     areagroup.group_order = payload.group_order
     areagroup.group_color = payload.group_color
     areagroup.save()
+    invalidate("areagroups")
     return {"success": True}
 
 
@@ -1080,6 +1129,7 @@ def update_area(request, area_id: int, payload: AreaIn):
     area.area_icon = payload.area_icon
     area.group_id = payload.group_id
     area.save()
+    invalidate("areas", "areagroups")
     return {"success": True}
 
 
@@ -1112,6 +1162,7 @@ def update_chore(request, chore_id: int, payload: ChoreIn):
     chore.assignee_id = payload.assignee_id
     chore.effort = payload.effort
     chore.save()
+    invalidate_pattern("chores:*")
     return {"success": True}
 
 
@@ -1135,6 +1186,7 @@ def toggle_chore(request, chore_id: int, payload: TogglActive):
     chore = get_object_or_404(Chore, id=chore_id)
     chore.status = payload.status
     chore.save()
+    invalidate_pattern("chores:*")
     return {"success": True}
 
 
@@ -1158,6 +1210,7 @@ def snooze_chore(request, chore_id: int, payload: SnoozeChore):
     chore = get_object_or_404(Chore, id=chore_id)
     chore.nextDue = payload.nextDue
     chore.save()
+    invalidate_pattern("chores:*")
     return {"success": True}
 
 
@@ -1181,6 +1234,7 @@ def claim_chore(request, chore_id: int, payload: ClaimChore):
     chore = get_object_or_404(Chore, id=chore_id)
     chore.assignee_id = payload.assignee_id
     chore.save()
+    invalidate_pattern("chores:*")
     return {"success": True}
 
 
@@ -1226,6 +1280,7 @@ def complete_chore(request, chore_id: int, payload: CompleteChore):
         completed_by_id=payload.completed_by_id,
         chore=chore,
     )
+    invalidate_pattern("chores:*", "weeklytotals:*")
     return {"success": True}
 
 
@@ -1251,6 +1306,7 @@ def update_historyitem(request, historyitem_id: int, payload: HistoryItemIn):
     historyitem.completed_by = payload.completed_by
     historyitem.chore_id = payload.chore_id
     historyitem.save()
+    invalidate_pattern("chores:*", "weeklytotals:*")
     return {"success": True}
 
 
@@ -1276,6 +1332,7 @@ def update_option(request, option_id: int, payload: OptionIn):
     option.med_thresh = payload.med_thresh
     option.high_thresh = payload.high_thresh
     option.save()
+    invalidate("options")
     return {"success": True}
 
 
@@ -1297,6 +1354,7 @@ def delete_areagroup(request, areagroup_id: int):
     """
     areagroup = get_object_or_404(AreaGroup, id=areagroup_id)
     areagroup.delete()
+    invalidate("areagroups")
     return {"success": True}
 
 
@@ -1318,6 +1376,7 @@ def delete_area(request, area_id: int):
     """
     area = get_object_or_404(Area, id=area_id)
     area.delete()
+    invalidate("areas", "areagroups")
     return {"success": True}
 
 
@@ -1339,6 +1398,7 @@ def delete_chore(request, chore_id: int):
     """
     chore = get_object_or_404(Chore, id=chore_id)
     chore.delete()
+    invalidate_pattern("chores:*")
     return {"success": True}
 
 
@@ -1360,6 +1420,7 @@ def delete_historyitem(request, historyitem_id: int):
     """
     historyitem = get_object_or_404(HistoryItem, id=historyitem_id)
     historyitem.delete()
+    invalidate_pattern("chores:*", "weeklytotals:*")
     return {"success": True}
 
 

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -150,6 +150,17 @@ MEDIA_ROOT = BASE_DIR / "mediafiles"
 
 CSRF_TRUSTED_ORIGINS = os.environ.get("CSRF_TRUSTED_ORIGINS").split(" ")
 
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": os.environ.get("REDIS_URL", "redis://redis:6379/0"),
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
+        "KEY_PREFIX": "lc",
+    }
+}
+
 CORS_ORIGIN_WHITELIST = os.environ.get("CSRF_TRUSTED_ORIGINS").split(" ")
 
 CORS_ALLOW_ALL_ORIGINS = True

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,3 +17,4 @@ django-colorfield==0.11.0
 django-q2==1.6.2
 arrow==1.3.0
 django-allauth[headless]==65.3.1
+django-redis==5.4.0

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -23,6 +23,7 @@ services:
       - 8000
     depends_on:
       - db
+      - redis
     networks:
       - default
     env_file:
@@ -41,6 +42,7 @@ services:
     depends_on:
       - db
       - backend
+      - redis
     networks:
       - default
     env_file:
@@ -49,6 +51,13 @@ services:
     container_name: lenorechore_worker
     environment:
       - DEBUG=0
+  redis:
+    image: redis:7-alpine
+    networks:
+      - default
+    container_name: lenorechore_redis
+    restart: unless-stopped
+
   db:
     image: postgres:15
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - 8002:8002
     depends_on:
       - db
+      - redis
     networks:
       - default
     env_file:
@@ -51,12 +52,20 @@ services:
     depends_on:
       - db
       - backend
+      - redis
     networks:
       - default
     env_file:
       - ./.env.dev
     image: lenorechore_worker:development
     container_name: lenorechore_worker_dev
+  redis:
+    image: redis:7-alpine
+    networks:
+      - default
+    container_name: lenorechore_redis_dev
+    restart: unless-stopped
+
   db:
     image: postgres:15
     volumes:


### PR DESCRIPTION
## Summary
- Add `django-redis` as a dependency
- Add `redis:7-alpine` container to dev and prod compose stacks
- Configure Django `CACHES` via `REDIS_URL` env var (defaults to `redis://redis:6379/0`)
- Cache list endpoints with 15 min TTL; invalidate immediately on any write

## Cached endpoints
| Endpoint | Cache key |
|---|---|
| `GET /areagroups` | `areagroups` |
| `GET /areas` | `areas` |
| `GET /chores` | `chores:{inactive}:{timeframe}:{assignee_id}:{area_id}` |
| `GET /options` | `options` |
| `GET /users` | `users` |
| `GET /weeklytotals` | `weeklytotals:{week}` |

## Invalidation
All POST/PUT/PATCH/DELETE endpoints delete the relevant cache keys immediately on success. Chore and history writes also clear `weeklytotals`. Vacation toggle clears both `options` and `chores`.

## Pre-deploy checklist
- [ ] Add `REDIS_URL=redis://redis:6379/0` to live `.env` before deploying to production

## Test plan
- [x] Dev stack tested locally — all endpoints functional, cache hits confirmed
- [ ] Sandbox test with live data
- [ ] Verify writes invalidate cache correctly (data reflects immediately after a change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)