### PR TITLE
fix: add missing blank line after invalidate_pattern (E305)

### DIFF
--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -34,6 +34,7 @@ def invalidate_pattern(*patterns):
     for pattern in patterns:
         cache.delete_pattern(pattern)
 
+
 api = NinjaAPI(auth=django_auth, csrf=True, urls_namespace="api_v2")
 router = Router()
 api.title = "LenoreChore API"


### PR DESCRIPTION
## Summary
- Fix E305 lint violation introduced in #20 — missing blank line after `invalidate_pattern` function definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)