### PR TITLE
feat: add dark/light theme toggle to app bar

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -40,11 +40,13 @@
 import AppNavigationVue from "./views/AppNavigation.vue";
 import { useChoreStore } from "@/stores/chores";
 import { useUserStore } from "@/stores/user";
+import { useThemeStore } from "@/stores/theme";
 import { onMounted, computed, ref, watch, onUnmounted } from "vue";
 import { VueQueryDevtools } from "@tanstack/vue-query-devtools";
 import { useVersion } from "@/composables/versionComposable";
 import { useQueryClient } from "@tanstack/vue-query";
 import { useRouter } from "vue-router";
+import { useTheme } from "vuetify";
 import axios from "axios";
 import { version as appVersion } from "../package.json";
 
@@ -53,6 +55,8 @@ const reloadPage = () => {
 };
 const chorestore = useChoreStore();
 const userstore = useUserStore();
+const themeStore = useThemeStore();
+const vuetifyTheme = useTheme();
 const router = useRouter();
 const queryClient = useQueryClient();
 const { prefetchVersion, version } = useVersion();
@@ -76,6 +80,20 @@ const checkSession = async () => {
     }
   }
 };
+
+// Apply persisted theme on load
+vuetifyTheme.global.name.value = themeStore.isDark
+  ? "myCustomDarkTheme"
+  : "myCustomLightTheme";
+
+watch(
+  () => themeStore.isDark,
+  isDark => {
+    vuetifyTheme.global.name.value = isDark
+      ? "myCustomDarkTheme"
+      : "myCustomLightTheme";
+  }
+);
 
 onMounted(async () => {
   const handleVisibilityChange = () => {

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -28,11 +28,35 @@ const myCustomLightTheme = {
   },
 };
 
+const myCustomDarkTheme = {
+  dark: true,
+  colors: {
+    primary: "#90CAF9",
+    secondary: "#4FC3F7",
+    accent: "#ffeb3b",
+    error: "#FF5252",
+    warning: "#FFB300",
+    info: "#BCAAA4",
+    success: "#69F0AE",
+    area1: "#1A237E",
+    area2: "#283593",
+    area3: "#303F9F",
+    area4: "#3949AB",
+    area5: "#3F51B5",
+    area6: "#5C6BC0",
+    user1: "#E91E63",
+    user2: "#3F51B5",
+    user3: "#009688",
+    user4: "#CDDC39",
+  },
+};
+
 export default createVuetify({
   theme: {
     defaultTheme: "myCustomLightTheme",
     themes: {
       myCustomLightTheme,
+      myCustomDarkTheme,
     },
   },
   icons: {

--- a/frontend/src/stores/theme
+++ b/frontend/src/stores/theme
@@ -1,0 +1,13 @@
+import { defineStore } from "pinia";
+
+export const useThemeStore = defineStore("theme", {
+  state: () => ({
+    isDark: false,
+  }),
+  actions: {
+    toggle() {
+      this.isDark = !this.isDark;
+    },
+  },
+  persist: true,
+});

--- a/frontend/src/views/AppNavigation.vue
+++ b/frontend/src/views/AppNavigation.vue
@@ -27,6 +27,11 @@
     <v-img :width="208" aspect-ratio="1/1" src="logov2.png" inline></v-img>
     <span class="text-subtitle-2 font-italic text-grey-darken-1">v{{ appVersion }}</span>
     <v-spacer></v-spacer>
+    <v-btn
+      :icon="themeStore.isDark ? 'mdi-weather-sunny' : 'mdi-weather-night'"
+      @click="themeStore.toggle()"
+      variant="text"
+    ></v-btn>
     <v-menu
       v-model="menu"
       :close-on-content-click="false"
@@ -69,12 +74,15 @@
 <script setup>
   import { ref } from "vue";
   import { useUserStore } from "@/stores/user";
+  import { useThemeStore } from "@/stores/theme";
   import AddAreaForm from "@/components/AddAreaForm.vue";
   import AddChoreForm from "@/components/AddChoreForm.vue";
   import AddAreaGroupForm from "@/components/AddAreaGroupForm.vue";
   import { useOptions } from "@/composables/optionsComposable";
   import VacationForm from "@/components/VacationForm.vue";
   import { version as appVersion } from "../../package.json";
+
+  const themeStore = useThemeStore();
 
   const { options } = useOptions();
   const showVacationForm = ref(false);


### PR DESCRIPTION
## Summary
- Add `myCustomDarkTheme` to Vuetify config
- Add dedicated `theme` Pinia store persisted to localStorage
- `App.vue` applies persisted theme on load and watches for store changes
- App bar toggle button switches between sun/moon icon and calls `themeStore.toggle()`

## Test plan
- [x] Toggle switches theme correctly
- [x] Theme persists across page refreshes
- [x] Light theme unchanged
- [ ] Sandbox test after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)