### PR TITLE
feat: mobile UI improvements

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,7 +3,7 @@
     <VueQueryDevtools />
     <AppNavigationVue />
     <v-main>
-      <v-container fluid class="pa-2">
+      <v-container fluid :class="$vuetify.display.smAndDown ? 'pa-0' : 'pa-2'">
         <router-view />
       </v-container>
       <v-snackbar

--- a/frontend/src/components/AddAreaForm.vue
+++ b/frontend/src/components/AddAreaForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="dialog" persistent width="1024">
+  <v-dialog v-model="dialog" persistent :fullscreen="$vuetify.display.smAndDown" width="1024">
     <template v-slot:activator="{ props }">
       <v-list-item key="1" v-bind="props" @click="menu = false">
         <template v-slot:prepend>

--- a/frontend/src/components/AddAreaGroupForm.vue
+++ b/frontend/src/components/AddAreaGroupForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="dialog" persistent width="1024">
+  <v-dialog v-model="dialog" persistent :fullscreen="$vuetify.display.smAndDown" width="1024">
     <template v-slot:activator="{ props }">
       <v-list-item key="1" v-bind="props">
         <template v-slot:prepend>

--- a/frontend/src/components/AddChoreForm.vue
+++ b/frontend/src/components/AddChoreForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="dialog" persistent width="1024">
+  <v-dialog v-model="dialog" persistent :fullscreen="$vuetify.display.smAndDown" width="1024">
     <template v-slot:activator="{ props }">
       <v-list-item key="2" v-bind="props">
         <template v-slot:prepend>

--- a/frontend/src/components/AreaCard.vue
+++ b/frontend/src/components/AreaCard.vue
@@ -37,7 +37,7 @@
         <v-container>
           <v-row dense>
             <v-col>
-              <v-dialog v-model="editcard" persistent width="1024">
+              <v-dialog v-model="editcard" persistent :fullscreen="$vuetify.display.smAndDown" width="1024">
                 <template v-slot:activator="{ props }">
                   <v-btn icon="mdi-note-edit-outline" v-bind="props"></v-btn>
                 </template>

--- a/frontend/src/components/VacationForm.vue
+++ b/frontend/src/components/VacationForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="show" persistent width="1024">
+  <v-dialog v-model="show" persistent :fullscreen="$vuetify.display.smAndDown" width="1024">
     <v-card>
       <v-card-title>
         <span class="text-h5">{{

--- a/frontend/src/views/AppNavigation.vue
+++ b/frontend/src/views/AppNavigation.vue
@@ -26,8 +26,8 @@
       <v-divider></v-divider>
       <v-list>
         <v-list-item>
-          <v-list-item-title class="text-caption font-italic text-medium-emphasis">
-            v{{ appVersion }}
+          <v-list-item-title class="text-body-2 font-italic text-secondary text-center">
+            version {{ appVersion }}
           </v-list-item-title>
         </v-list-item>
       </v-list>

--- a/frontend/src/views/AppNavigation.vue
+++ b/frontend/src/views/AppNavigation.vue
@@ -23,9 +23,16 @@
         <AddChoreForm />
         <AddAreaGroupForm />
       </v-list>
+      <v-divider></v-divider>
+      <v-list>
+        <v-list-item>
+          <v-list-item-title class="text-caption font-italic text-medium-emphasis">
+            v{{ appVersion }}
+          </v-list-item-title>
+        </v-list-item>
+      </v-list>
     </v-menu>
     <v-img :width="208" aspect-ratio="1/1" src="logov2.png" inline></v-img>
-    <span class="text-subtitle-2 font-italic text-grey-darken-1">v{{ appVersion }}</span>
     <v-spacer></v-spacer>
     <v-btn
       :icon="themeStore.isDark ? 'mdi-weather-sunny' : 'mdi-weather-night'"

--- a/frontend/src/views/DashView.vue
+++ b/frontend/src/views/DashView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="areas">
-    <v-container>
+    <v-container :class="$vuetify.display.smAndDown ? 'pa-0' : ''">
       <v-row dense v-if="!isLoading">
         <v-col cols="12">
           <AreaCard

--- a/frontend/src/views/ListView.vue
+++ b/frontend/src/views/ListView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="chores">
-    <v-container :class="$vuetify.display.smAndDown ? 'pa-0' : ''">
+    <v-container :class="$vuetify.display.smAndDown ? 'px-0 pt-2' : ''">
       <v-row dense>
         <v-col cols="12">
           <v-row dense>

--- a/frontend/src/views/ListView.vue
+++ b/frontend/src/views/ListView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="chores">
-    <v-container>
+    <v-container :class="$vuetify.display.smAndDown ? 'pa-0' : ''">
       <v-row dense>
         <v-col cols="12">
           <v-row dense>


### PR DESCRIPTION
## Summary
- Forms open fullscreen on mobile (smAndDown): AddAreaGroup, AddArea, AddChore, VacationForm, AreaCard edit dialog
- Chore cards and area list extend edge-to-edge on mobile (no horizontal padding)
- Top padding preserved on list view so filters don't sit flush against app bar
- Version string moved from app bar to bottom of nav menu (prevents squashing on mobile with dark mode toggle)
- Version display styled: body-2 size, centered, secondary color, "version x.x.x" format

## Test plan
- [x] Forms fullscreen on mobile, normal dialog on desktop
- [x] Cards edge-to-edge on mobile
- [x] Filters have breathing room below app bar
- [x] App bar clean on mobile with dark mode toggle visible
- [x] Version visible at bottom of nav menu
- [ ] Sandbox test after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)