### PR TITLE
docs: overhaul documentation versioning, inline docstrings, and content

### DIFF
--- a/.github/workflows/deploy-docs-release.yml
+++ b/.github/workflows/deploy-docs-release.yml
@@ -47,4 +47,5 @@ jobs:
 
           if [[ "${{ github.event.release.prerelease }}" != "true" ]]; then
             mike alias "$MAJOR_MINOR" latest --push --config-file backend/mkdocs.yml
+            mike set-default latest --push --config-file backend/mkdocs.yml
           fi

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -12,9 +12,10 @@ import os
 
 class SingletonModel(models.Model):
     """
-    Model representing a singleton model.
+    Abstract base model that enforces a single instance.
 
-    Attributes:
+    Subclasses may only have one row in the database. Attempting to create
+    a second instance raises a ValidationError, and deletion is also blocked.
     """
 
     class Meta:
@@ -36,6 +37,16 @@ class SingletonModel(models.Model):
 
 
 def user_profile_picture_upload(instance, filename):
+    """
+    Generate an upload path for a user's profile picture.
+
+    Args:
+        instance (CustomUser): The user instance being saved.
+        filename (str): The original filename of the uploaded image.
+
+    Returns:
+        str: Upload path in the form ``profile_pictures/<email><ext>``.
+    """
     _, file_extension = os.path.splitext(filename)
 
     return f"profile_pictures/{instance.email}{file_extension}"
@@ -85,6 +96,12 @@ class CustomUser(AbstractUser):
 
     @property
     def fullname(self):
+        """
+        Returns the user's full name as a single string.
+
+        Returns:
+            str: First name and last name joined by a space.
+        """
         fullname = self.first_name + " " + self.last_name
         return fullname
 
@@ -211,7 +228,7 @@ class Month(models.Model):
 
 class Chore(models.Model):
     """
-    Model representing a month.
+    Model representing a chore.
 
     Attributes:
         chore_name (CharField): The name of the chore. Max=254
@@ -324,6 +341,12 @@ class Option(SingletonModel):
 
     @classmethod
     def load(cls):
+        """
+        Load the singleton Option instance.
+
+        Returns:
+            Option: The first (and only) Option object, or None if not yet created.
+        """
         return cls.objects.first()
 
 

--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -119,6 +119,15 @@ class CustomUserSchema(Schema):
 
     @staticmethod
     def resolve_groups(obj):
+        """
+        Resolve the groups field to a list of group IDs.
+
+        Args:
+            obj (CustomUser): The user instance being serialized.
+
+        Returns:
+            List[int]: List of group IDs the user belongs to.
+        """
         return [group.id for group in obj.groups.all()]
 
 

--- a/backend/docs/api.md
+++ b/backend/docs/api.md
@@ -1,3 +1,7 @@
+## Helpers
+#### ::: backend.api.invalidate
+#### ::: backend.api.invalidate_pattern
+
 ## CustomUser
 ### Views
 #### ::: backend.api.list_users
@@ -40,7 +44,6 @@
 #### ::: backend.api.list_chores
 #### ::: backend.api.update_chore
 #### ::: backend.api.delete_chore
-#### ::: backend.api.toggle_vacation
 #### ::: backend.api.calculate_duedays
 #### ::: backend.api.toggle_chore
 #### ::: backend.api.snooze_chore
@@ -73,6 +76,7 @@
 #### ::: backend.api.get_option
 #### ::: backend.api.list_options
 #### ::: backend.api.update_option
+#### ::: backend.api.toggle_vacation
 ### Schemas
 #### ::: backend.api.OptionIn
 #### ::: backend.api.OptionOut

--- a/backend/docs/index.md
+++ b/backend/docs/index.md
@@ -113,11 +113,12 @@ SQL_PASSWORD=somepassword
 SQL_HOST=db
 SQL_PORT=5432
 DATABASE=postgres
-DJANGO_SUPERUSER_PASSWORD=suepervisorpassword
+DJANGO_SUPERUSER_PASSWORD=supervisorpassword
 DJANGO_SUPERUSER_EMAIL=someone@somewhere.com
 DJANGO_SUPERUSER_USERNAME=supervisor
 VITE_API_KEY=someapikey
 TIMEZONE=America/New_York
+REDIS_URL=redis://redis:6379/0
 ```
 
 Adjust these values according to your environment and application requirements.
@@ -129,7 +130,7 @@ Create a `docker-compose.yml` file in the root directory of the project. Below i
 ```yaml
 services:
   frontend:
-    image: novanglus96/LenoreChore_frontend:latest
+    image: novanglus96/lenorechore_frontend:latest
     container_name: LenoreChore_frontend
     networks:
       - LenoreChore
@@ -139,7 +140,7 @@ services:
     env_file:
       - ./.env
   backend:
-    image: novanglus96/LenoreChore_backend:latest
+    image: novanglus96/lenorechore_backend:latest
     container_name: LenoreChore_backend
     command: /home/app/web/start.sh
     volumes:
@@ -149,6 +150,21 @@ services:
       - 8000
     depends_on:
       - db
+      - redis
+    networks:
+      - LenoreChore
+    env_file:
+      - ./.env
+  worker:
+    image: novanglus96/lenorechore_backend:latest
+    container_name: LenoreChore_worker
+    command: /home/app/web/start.worker.sh
+    volumes:
+      - LenoreChore_static_volume:/home/app/web/staticfiles
+      - LenoreChore_media_volume:/home/app/web/mediafiles
+    depends_on:
+      - db
+      - redis
     networks:
       - LenoreChore
     env_file:
@@ -166,6 +182,12 @@ services:
       - POSTGRES_USER=${SQL_USER}
       - POSTGRES_PASSWORD=${SQL_PASSWORD}
       - POSTGRES_DB=${SQL_DATABASE}
+  redis:
+    image: redis:7-alpine
+    container_name: LenoreChore_redis
+    networks:
+      - LenoreChore
+    restart: unless-stopped
   nginx:
     image: novanglus96/lenoreapps_proxy:latest
     container_name: LenoreChore_nginx
@@ -216,7 +238,11 @@ Enjoy using LenoreChore!
 <!-- ROADMAP -->
 ## Roadmap
 
-- [ ] v1.3 Release
+- [x] v1.3 Release
+    - [x] Redis caching with write-through invalidation
+    - [x] Form validation (vee-validate + yup)
+    - [x] Dark/light theme toggle (persisted per browser)
+    - [x] Mobile UI improvements (edge-to-edge cards, fullscreen forms)
     - [ ] Demo Data
 
 See the [open issues](https://github.com/Novanglus96/LenoreChore/issues) for a full list of proposed features (and known issues).

--- a/backend/docs/models.md
+++ b/backend/docs/models.md
@@ -33,6 +33,9 @@
 
 ## Option
 ### ::: api.models.Option
+        options:
+            members:
+                - load
 
 ## Version
 ### ::: api.models.Version

--- a/backend/docs/models.md
+++ b/backend/docs/models.md
@@ -5,6 +5,9 @@
                 - save
                 - delete
 ### ::: api.models.CustomUser
+        options:
+            members:
+                - fullname
 
 ## Area Group
 ### ::: api.models.AreaGroup

--- a/backend/mkdocs.yml
+++ b/backend/mkdocs.yml
@@ -22,6 +22,10 @@ theme:
       toggle:
         icon: material/weather-night
         name: Switch to dark mode
+extra:
+  version:
+    provider: mike
+
 plugins:
   - search
   - mkdocstrings:


### PR DESCRIPTION
## Summary
- **MkDocs versioning**: Added `extra.version.provider: mike` to `mkdocs.yml` so the version selector dropdown appears in the Material theme UI
- **Docs deploy workflow**: Added `mike set-default latest` on stable releases so the root docs URL redirects to the latest version instead of showing a version list
- **Inline docstrings**:
  - Fixed `Chore` model docstring (copy-paste error said "month" instead of "chore")
  - Added docstrings to `user_profile_picture_upload`, `CustomUser.fullname`, `Option.load`, `SingletonModel` (improved), and `CustomUserSchema.resolve_groups`
- **`docs/models.md`**: Added `Option.load` classmethod to the reference docs
- **`docs/index.md`**:
  - Updated docker-compose example to include `redis` and `worker` services (added in v1.3)
  - Added `REDIS_URL` to the `.env` example
  - Fixed typo in superuser password field name
  - Updated roadmap to reflect completed v1.3 features

## Test plan
- [ ] Verify docs build locally: `cd backend && mkdocs build`
- [ ] Merge and confirm deploy-docs workflow publishes correctly with version selector visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)