### PR TITLE
fix: use DummyCache instead of LocMemCache when Redis is unavailable

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -172,7 +172,7 @@ if os.environ.get("REDIS_URL"):
 else:
     CACHES = {
         "default": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
         }
     }
 


### PR DESCRIPTION
## Summary
- Replaces `LocMemCache` fallback with `DummyCache` when `REDIS_URL` is not set
- `LocMemCache` is per-process — in a multi-worker gunicorn setup each worker has an isolated cache, so invalidation in one worker doesn't affect others, causing stale UI reads
- `DummyCache` disables caching entirely, ensuring consistent reads in a no-Redis deployment (small performance cost, but correctness is non-negotiable)

## Test plan
- [ ] Verify assignment changes update immediately in UI without Redis

🤖 Generated with [Claude Code](https://claude.com/claude-code)