### PR TITLE
feat: offline data pre-caching and optimistic UI updates

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -102,6 +102,7 @@ import { onMounted, computed, ref, watch, onUnmounted } from "vue";
 import { VueQueryDevtools } from "@tanstack/vue-query-devtools";
 import { useVersion } from "@/composables/versionComposable";
 import { useSync } from "@/composables/syncComposable";
+import { usePrefetch } from "@/composables/prefetchComposable";
 import { useQueryClient } from "@tanstack/vue-query";
 import { useRouter } from "vue-router";
 import { useTheme } from "vuetify";
@@ -121,6 +122,7 @@ const router = useRouter();
 const queryClient = useQueryClient();
 const { prefetchVersion, version } = useVersion();
 const { replayQueue } = useSync();
+const { prefetchCriticalData } = usePrefetch();
 
 const showBanner = ref(false);
 const showInstallPrompt = ref(false);
@@ -184,13 +186,16 @@ const installApp = async () => {
 
 // ── Lifecycle ───────────────────────────────────────────────────────────────
 onMounted(async () => {
-  // Visibility / version polling
+  // Visibility / version polling + data prefetch
   const handleVisibilityChange = () => {
     if (!document.hidden) {
       checkSession();
       prefetchVersion().then(() => {
         updateBanner();
       });
+      if (userstore.isLoggedIn) {
+        prefetchCriticalData();
+      }
     }
   };
   document.addEventListener("visibilitychange", handleVisibilityChange);
@@ -238,6 +243,11 @@ onMounted(async () => {
   prefetchVersion();
   updateBanner();
 
+  // Pre-warm critical API data in TanStack Query + Workbox cache
+  if (userstore.isLoggedIn) {
+    prefetchCriticalData();
+  }
+
   // Replay any mutations that were queued in a previous offline session
   if (offlineStore.isOnline && offlineStore.mutationQueue.length > 0) {
     replayQueue();
@@ -253,6 +263,8 @@ watch(
   (isLoggedIn) => {
     if (!isLoggedIn) {
       queryClient.clear();
+    } else {
+      prefetchCriticalData();
     }
   }
 );

--- a/frontend/src/composables/choresComposasble.js
+++ b/frontend/src/composables/choresComposasble.js
@@ -149,6 +149,21 @@ export function useChores() {
 
   const completeChoreMutation = useMutation({
     mutationFn: completeChoreFunction,
+    onMutate: async (completedChore) => {
+      await queryClient.cancelQueries({ queryKey: ["chores"] });
+      const snapshots = queryClient.getQueriesData({ queryKey: ["chores"] });
+      queryClient.setQueriesData({ queryKey: ["chores"] }, (old) =>
+        Array.isArray(old) ? old.filter((c) => c.id !== completedChore.id) : old
+      );
+      return { snapshots };
+    },
+    onError: (error, _vars, context) => {
+      if (!error.queued) {
+        context?.snapshots?.forEach(([key, data]) =>
+          queryClient.setQueryData(key, data)
+        );
+      }
+    },
     onSuccess: () => {
       console.log("Success completing chore");
       queryClient.invalidateQueries({ queryKey: ["chores"] });
@@ -160,6 +175,25 @@ export function useChores() {
 
   const snoozeChoreMutation = useMutation({
     mutationFn: snoozeChoreFunction,
+    onMutate: async (snoozedChore) => {
+      await queryClient.cancelQueries({ queryKey: ["chores"] });
+      const snapshots = queryClient.getQueriesData({ queryKey: ["chores"] });
+      queryClient.setQueriesData({ queryKey: ["chores"] }, (old) =>
+        Array.isArray(old)
+          ? old.map((c) =>
+              c.id === snoozedChore.id ? { ...c, nextDue: snoozedChore.nextDue } : c
+            )
+          : old
+      );
+      return { snapshots };
+    },
+    onError: (error, _vars, context) => {
+      if (!error.queued) {
+        context?.snapshots?.forEach(([key, data]) =>
+          queryClient.setQueryData(key, data)
+        );
+      }
+    },
     onSuccess: () => {
       console.log("Success snoozing chore");
       queryClient.invalidateQueries({ queryKey: ["chores"] });
@@ -169,6 +203,35 @@ export function useChores() {
 
   const claimChoreMutation = useMutation({
     mutationFn: claimChoreFunction,
+    onMutate: async (claimedChore) => {
+      await queryClient.cancelQueries({ queryKey: ["chores"] });
+      const snapshots = queryClient.getQueriesData({ queryKey: ["chores"] });
+      const users = queryClient.getQueryData(["users"]);
+      const newAssignee =
+        users?.find((u) => u.id === claimedChore.assignee_id) ?? null;
+      queryClient.setQueriesData({ queryKey: ["chores"] }, (old) =>
+        Array.isArray(old)
+          ? old.map((c) =>
+              c.id === claimedChore.id
+                ? {
+                    ...c,
+                    assignee_id: claimedChore.assignee_id,
+                    assignee: newAssignee,
+                    isAssigned: !!claimedChore.assignee_id,
+                  }
+                : c
+            )
+          : old
+      );
+      return { snapshots };
+    },
+    onError: (error, _vars, context) => {
+      if (!error.queued) {
+        context?.snapshots?.forEach(([key, data]) =>
+          queryClient.setQueryData(key, data)
+        );
+      }
+    },
     onSuccess: () => {
       console.log("Success claiming chore");
       queryClient.invalidateQueries({ queryKey: ["chores"] });
@@ -178,6 +241,25 @@ export function useChores() {
 
   const toggleChoreMutation = useMutation({
     mutationFn: toggleChoreFunction,
+    onMutate: async (toggledChore) => {
+      await queryClient.cancelQueries({ queryKey: ["chores"] });
+      const snapshots = queryClient.getQueriesData({ queryKey: ["chores"] });
+      queryClient.setQueriesData({ queryKey: ["chores"] }, (old) =>
+        Array.isArray(old)
+          ? old.map((c) =>
+              c.id === toggledChore.id ? { ...c, status: toggledChore.status } : c
+            )
+          : old
+      );
+      return { snapshots };
+    },
+    onError: (error, _vars, context) => {
+      if (!error.queued) {
+        context?.snapshots?.forEach(([key, data]) =>
+          queryClient.setQueryData(key, data)
+        );
+      }
+    },
     onSuccess: () => {
       console.log("Success toggling chore");
       queryClient.invalidateQueries({ queryKey: ["chores"] });

--- a/frontend/src/composables/prefetchComposable.js
+++ b/frontend/src/composables/prefetchComposable.js
@@ -1,0 +1,50 @@
+import { useQueryClient } from "@tanstack/vue-query";
+import apiClient from "@/api/client";
+
+// Default filters matching the chore list default state
+const DEFAULT_CHORE_FILTERS = {
+  inactive: false,
+  timeframe: null,
+  assignee_id: null,
+  area_id: null,
+};
+
+export function usePrefetch() {
+  const queryClient = useQueryClient();
+
+  async function prefetchCriticalData() {
+    // Only prefetch if data is older than 2 minutes to avoid redundant fetches
+    const staleTime = 2 * 60 * 1000;
+
+    await Promise.allSettled([
+      queryClient.prefetchQuery({
+        queryKey: ["chores", DEFAULT_CHORE_FILTERS],
+        queryFn: () =>
+          apiClient.get("/chores?inactive=false").then((r) => r.data),
+        staleTime,
+      }),
+      queryClient.prefetchQuery({
+        queryKey: ["areas"],
+        queryFn: () => apiClient.get("/areas").then((r) => r.data),
+        staleTime,
+      }),
+      queryClient.prefetchQuery({
+        queryKey: ["areagroups"],
+        queryFn: () => apiClient.get("/areagroups").then((r) => r.data),
+        staleTime,
+      }),
+      queryClient.prefetchQuery({
+        queryKey: ["options"],
+        queryFn: () => apiClient.get("/options/1").then((r) => r.data),
+        staleTime,
+      }),
+      queryClient.prefetchQuery({
+        queryKey: ["users"],
+        queryFn: () => apiClient.get("/users").then((r) => r.data),
+        staleTime,
+      }),
+    ]);
+  }
+
+  return { prefetchCriticalData };
+}

--- a/frontend/src/utils/apiErrorHandler.js
+++ b/frontend/src/utils/apiErrorHandler.js
@@ -2,7 +2,7 @@ import { useChoreStore } from "@/stores/chores";
 
 export function handleApiError(error, message) {
   if (error.response?.status === 401) throw error;
-  if (error.queued) return; // Action was queued for offline sync — no UI error needed
+  if (error.queued) throw error; // Propagate to onError so optimistic UI update is kept until sync
 
   const chorestore = useChoreStore();
   if (error.response) {


### PR DESCRIPTION
## Summary

### Pre-caching critical data
- New `prefetchComposable` warms chores, areas, areagroups, options, and users on app mount, login, and every visibility change
- Both TanStack Query cache (in-memory) and Workbox cache (service worker) are populated — data is available offline even if the user hasn't explicitly navigated to those views

### Optimistic UI updates
- `complete`, `snooze`, `claim`, and `toggle` mutations now update the TanStack Query cache **immediately** via `onMutate` — the UI responds before the server confirms
- On real server errors: `onError` rolls back to the previous snapshot
- On offline/queued mutations: `onError` keeps the optimistic state — the change stays visible in the UI until background sync completes
- `handleApiError` now re-throws queued errors so TanStack Query routes them through `onError` (not `onSuccess`), preventing premature cache invalidation that would overwrite the optimistic update with stale cached data

## Test plan
- [ ] Complete/snooze/claim/toggle a chore while **online** — UI updates immediately, no flicker
- [ ] Complete/snooze/claim/toggle a chore while **offline** — UI updates immediately, change persists until sync
- [ ] Reconnect — sync fires, data refreshes from server, UI reflects server state
- [ ] Load app while online, go offline, navigate to chore list — data is present from cache
- [ ] Real server error (e.g. force a 500) — UI rolls back the optimistic change

🤖 Generated with [Claude Code](https://claude.ai/claude-code)