### PR TITLE
fix: improve PWA offline UX

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -37,23 +37,6 @@
         </template>
       </v-snackbar>
 
-      <!-- Offline indicator -->
-      <v-snackbar
-        v-model="offlineStore.isOnline"
-        color="warning"
-        location="top"
-        timeout="-1"
-        :model-value="!offlineStore.isOnline"
-      >
-        <v-icon start>mdi-wifi-off</v-icon>
-        You are offline.
-        <span v-if="offlineStore.mutationQueue.length > 0">
-          {{ offlineStore.mutationQueue.length }} change{{
-            offlineStore.mutationQueue.length !== 1 ? "s" : ""
-          }}
-          pending sync.
-        </span>
-      </v-snackbar>
 
       <!-- PWA install prompt (Android/Chrome) -->
       <v-snackbar

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -42,19 +42,13 @@ apiClient.interceptors.response.use(
 
     if (isNetworkError && isMutation) {
       const { useOfflineStore } = await import("@/stores/offline");
-      const { useChoreStore } = await import("@/stores/chores");
       const offlineStore = useOfflineStore();
-      const chorestore = useChoreStore();
 
       offlineStore.enqueue({
         method: error.config.method,
         url: error.config.url,
         data: error.config.data ? JSON.parse(error.config.data) : null,
       });
-      chorestore.showSnackbar(
-        "You are offline. This action will sync when you reconnect.",
-        "warning"
-      );
 
       const queuedError = new Error("Queued for offline sync");
       queuedError.queued = true;

--- a/frontend/src/composables/choresComposasble.js
+++ b/frontend/src/composables/choresComposasble.js
@@ -158,7 +158,12 @@ export function useChores() {
       return { snapshots };
     },
     onError: (error, _vars, context) => {
-      if (!error.queued) {
+      if (error.queued) {
+        chorestore.showSnackbar(
+          "Chore marked complete — will sync when reconnected",
+          "warning"
+        );
+      } else {
         context?.snapshots?.forEach(([key, data]) =>
           queryClient.setQueryData(key, data)
         );
@@ -188,7 +193,12 @@ export function useChores() {
       return { snapshots };
     },
     onError: (error, _vars, context) => {
-      if (!error.queued) {
+      if (error.queued) {
+        chorestore.showSnackbar(
+          "Chore snoozed — will sync when reconnected",
+          "warning"
+        );
+      } else {
         context?.snapshots?.forEach(([key, data]) =>
           queryClient.setQueryData(key, data)
         );
@@ -226,7 +236,12 @@ export function useChores() {
       return { snapshots };
     },
     onError: (error, _vars, context) => {
-      if (!error.queued) {
+      if (error.queued) {
+        chorestore.showSnackbar(
+          "Chore assignment updated — will sync when reconnected",
+          "warning"
+        );
+      } else {
         context?.snapshots?.forEach(([key, data]) =>
           queryClient.setQueryData(key, data)
         );
@@ -254,7 +269,12 @@ export function useChores() {
       return { snapshots };
     },
     onError: (error, _vars, context) => {
-      if (!error.queued) {
+      if (error.queued) {
+        chorestore.showSnackbar(
+          "Chore toggled — will sync when reconnected",
+          "warning"
+        );
+      } else {
         context?.snapshots?.forEach(([key, data]) =>
           queryClient.setQueryData(key, data)
         );

--- a/frontend/src/composables/syncComposable.js
+++ b/frontend/src/composables/syncComposable.js
@@ -15,8 +15,6 @@ export function useSync() {
     let succeeded = 0;
     let failed = 0;
 
-    chorestore.showSnackbar("Syncing offline changes...", "info");
-
     for (const mutation of queue) {
       try {
         await apiClient.request({
@@ -31,7 +29,7 @@ export function useSync() {
           // Still offline — stop replaying
           break;
         }
-        // Server error: count retries, discard after max
+        // Server error: count retries, discard after max attempts
         offlineStore.incrementRetries(mutation.id);
         if (mutation.retries + 1 >= 3) {
           offlineStore.dequeue(mutation.id);
@@ -42,14 +40,10 @@ export function useSync() {
 
     if (succeeded > 0) {
       queryClient.invalidateQueries();
-      chorestore.showSnackbar(
-        `Synced ${succeeded} offline change${succeeded !== 1 ? "s" : ""}`,
-        "success"
-      );
     }
     if (failed > 0) {
       chorestore.showSnackbar(
-        `${failed} change${failed !== 1 ? "s" : ""} could not be synced and were discarded`,
+        `${failed} offline change${failed !== 1 ? "s" : ""} could not be applied and were discarded`,
         "error"
       );
     }

--- a/frontend/src/views/AppNavigation.vue
+++ b/frontend/src/views/AppNavigation.vue
@@ -34,6 +34,31 @@
     </v-menu>
     <v-img :width="208" aspect-ratio="1/1" src="logov2.png" inline></v-img>
     <v-spacer></v-spacer>
+    <v-tooltip
+      v-if="!offlineStore.isOnline"
+      location="bottom"
+      max-width="260"
+    >
+      <template v-slot:activator="{ props }">
+        <v-btn
+          v-bind="props"
+          icon="mdi-wifi-off"
+          color="warning"
+          variant="text"
+        ></v-btn>
+      </template>
+      <span>
+        You are offline.
+        <template v-if="offlineStore.mutationQueue.length > 0">
+          {{ offlineStore.mutationQueue.length }}
+          change{{ offlineStore.mutationQueue.length !== 1 ? "s" : "" }}
+          saved locally and will sync automatically when reconnected.
+        </template>
+        <template v-else>
+          Changes you make will be saved locally and sync when reconnected.
+        </template>
+      </span>
+    </v-tooltip>
     <v-btn
       :icon="themeStore.isDark ? 'mdi-weather-sunny' : 'mdi-weather-night'"
       @click="themeStore.toggle()"
@@ -82,6 +107,7 @@
   import { ref } from "vue";
   import { useUserStore } from "@/stores/user";
   import { useThemeStore } from "@/stores/theme";
+  import { useOfflineStore } from "@/stores/offline";
   import AddAreaForm from "@/components/AddAreaForm.vue";
   import AddChoreForm from "@/components/AddChoreForm.vue";
   import AddAreaGroupForm from "@/components/AddAreaGroupForm.vue";
@@ -90,6 +116,7 @@
   import { version as appVersion } from "../../package.json";
 
   const themeStore = useThemeStore();
+  const offlineStore = useOfflineStore();
 
   const { options } = useOptions();
   const showVacationForm = ref(false);


### PR DESCRIPTION
## Summary

- **Offline indicator**: replaced the persistent blocking snackbar with a `mdi-wifi-off` icon in the app bar. Hovering/tapping shows a tooltip with queue depth and a message about auto-sync on reconnection
- **Action-specific queued messages**: complete/snooze/claim/toggle now each show a distinct "will sync when reconnected" snackbar via `onError`, matching the style of online confirmations ("Chore marked complete — will sync when reconnected" etc.)
- **Removed generic interceptor message**: the axios interceptor no longer shows "You are offline" — context is now surfaced where the action is known (the mutation)
- **Removed reconnect sync messages**: "Syncing offline changes..." and "Synced X changes" snackbars removed — the UI was already updated optimistically so these were confusing. Only discard-on-failure errors are still shown

## Test plan
- [ ] Go offline — wifi-off icon appears in app bar, no blocking banner
- [ ] Hover/tap the icon — tooltip shows queue count and sync message
- [ ] Complete a chore offline — UI updates immediately, snackbar says "Chore marked complete — will sync when reconnected"
- [ ] Snooze/claim/toggle offline — each shows its own specific message
- [ ] Reconnect — changes sync silently, UI stays consistent, no confusing success banner

🤖 Generated with [Claude Code](https://claude.ai/claude-code)