### PR TITLE
fix: self-host Roboto font to eliminate mixed content on HTTPS

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "frontend",
-  "version": "1.3.0-rc.15",
+  "version": "1.3.0-rc.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.3.0-rc.15",
+      "version": "1.3.0-rc.18",
       "dependencies": {
         "@bhplugin/vue3-datatable": "^1.1.4",
+        "@fontsource/roboto": "^5.2.10",
         "@headlessui/vue": "^1.7.22",
         "@heroicons/vue": "^2.1.3",
         "@tanstack/vue-query": "^5.40.1",
@@ -27,7 +28,6 @@
         "vue-router": "^4.3.2",
         "vuetify": "^3.6.8",
         "vuex": "^4.1.0",
-        "webfontloader": "^1.6.28",
         "yup": "^1.7.1"
       },
       "devDependencies": {
@@ -2162,6 +2162,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@fontsource/roboto": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.2.10.tgz",
+      "integrity": "sha512-8HlA5FtSfz//oFSr2eL7GFXAiE7eIkcGOtx7tjsLKq+as702x9+GU7K95iDeWFapHC4M2hv9RrpXKRTGGBI8Zg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@headlessui/vue": {
@@ -8691,10 +8700,6 @@
       "peerDependencies": {
         "vue": "^3.2.0"
       }
-    },
-    "node_modules/webfontloader": {
-      "version": "1.6.28",
-      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@bhplugin/vue3-datatable": "^1.1.4",
+    "@fontsource/roboto": "^5.2.10",
     "@headlessui/vue": "^1.7.22",
     "@heroicons/vue": "^2.1.3",
     "@tanstack/vue-query": "^5.40.1",
@@ -30,7 +31,6 @@
     "vue-router": "^4.3.2",
     "vuetify": "^3.6.8",
     "vuex": "^4.1.0",
-    "webfontloader": "^1.6.28",
     "yup": "^1.7.1"
   },
   "devDependencies": {

--- a/frontend/src/plugins/webfontloader.js
+++ b/frontend/src/plugins/webfontloader.js
@@ -1,17 +1,15 @@
 /**
  * plugins/webfontloader.js
  *
- * webfontloader documentation: https://github.com/typekit/webfontloader
+ * Self-hosted via @fontsource/roboto — no external HTTP requests,
+ * works offline and avoids mixed-content issues on HTTPS origins.
  */
 
 export async function loadFonts() {
-  const webFontLoader = await import(
-    /* webpackChunkName: "webfontloader" */ "webfontloader"
-  );
-
-  webFontLoader.load({
-    google: {
-      families: ["Roboto:100,300,400,500,700,900&display=swap"],
-    },
-  });
+  await import("@fontsource/roboto/100.css");
+  await import("@fontsource/roboto/300.css");
+  await import("@fontsource/roboto/400.css");
+  await import("@fontsource/roboto/500.css");
+  await import("@fontsource/roboto/700.css");
+  await import("@fontsource/roboto/900.css");
 }


### PR DESCRIPTION
## Summary

Replace `webfontloader` (which requests fonts from `http://fonts.googleapis.com`) with `@fontsource/roboto`. Fonts are now bundled with the app and precached by the service worker.

## Why

`webfontloader` constructs an HTTP (not HTTPS) `<link>` tag for Google Fonts. Chrome on Android's strict mixed content policy blocks this even when the page itself is HTTPS, causing:
- SW registration failure
- `beforeinstallprompt` never firing → no install prompt on Android
- "contains insecure resources" security warning

## Test plan
- [ ] App loads correctly with no mixed content warnings in DevTools
- [ ] Install prompt fires on Android Chrome over HTTPS
- [ ] Fonts render correctly (Roboto at all weights)
- [ ] Fonts available offline (precached by SW)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)