### PR TITLE
fix: trust X-Forwarded-Proto header from reverse proxy

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -158,6 +158,11 @@ MEDIA_ROOT = BASE_DIR / "mediafiles"
 
 CSRF_TRUSTED_ORIGINS = os.environ.get("CSRF_TRUSTED_ORIGINS").split(" ")
 
+# Trust the X-Forwarded-Proto header from reverse proxies (e.g. Traefik)
+# so Django generates https:// URLs for media files and other absolute URLs
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED_HOST = True
+
 if os.environ.get("REDIS_URL"):
     CACHES = {
         "default": {


### PR DESCRIPTION
## Summary

Add `SECURE_PROXY_SSL_HEADER` and `USE_X_FORWARDED_HOST` to Django settings.

## Why

Traefik terminates SSL and forwards plain HTTP to the app container. Without these settings, Django sees `http://` on every request and generates `http://` absolute URLs for media files (profile pictures, uploaded images). Chrome flags these as mixed content, which:
- Blocks PWA service worker registration on Android
- Shows "contains insecure resources" security warning
- Prevents the install prompt from firing

With `SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")`, Django reads Traefik's forwarded header and correctly generates `https://` URLs.

**Note:** Ensure Traefik is configured to send the `X-Forwarded-Proto: https` header (it does by default for HTTPS entrypoints).

## Test plan
- [ ] Profile pictures load without mixed content warnings
- [ ] No mixed content errors in DevTools console
- [ ] PWA service worker registers successfully on Android over HTTPS
- [ ] Install prompt fires on Android Chrome

🤖 Generated with [Claude Code](https://claude.ai/claude-code)