### PR TITLE
fix: forward X-Forwarded-Proto through nginx to resolve mixed content

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -158,6 +158,11 @@ MEDIA_ROOT = BASE_DIR / "mediafiles"
 
 CSRF_TRUSTED_ORIGINS = os.environ.get("CSRF_TRUSTED_ORIGINS").split(" ")
 
+# Trust the X-Forwarded-Proto header from reverse proxies (e.g. Traefik)
+# so Django generates https:// URLs for media files and other absolute URLs
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED_HOST = True
+
 if os.environ.get("REDIS_URL"):
     CACHES = {
         "default": {

--- a/nginx/app.conf
+++ b/nginx/app.conf
@@ -14,6 +14,7 @@ server {
         proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
         proxy_redirect off;
     }
 
@@ -22,6 +23,7 @@ server {
         proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
         proxy_redirect off;
     }
 
@@ -30,6 +32,7 @@ server {
         proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
         proxy_redirect off;
     }
 


### PR DESCRIPTION
## Summary

- Adds `proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;` to all three Django proxy location blocks in nginx (`/api/`, `/admin/`, `/_allauth/`)
- Traefik sets this header when terminating TLS, but nginx was silently dropping it before passing requests to Django
- Without this, Django's `SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")` (added in PR #37) had no effect — Django still saw plain HTTP and generated `http://` absolute URLs for media files
- Mixed-content errors on HTTPS sandbox should be resolved once deployed

## Test plan

- [ ] Deploy to sandbox (`sandbox.danielleandjohn.love`)
- [ ] Open Chrome DevTools → Console/Network — confirm no mixed-content warnings
- [ ] Confirm Chrome on Android no longer marks site as insecure
- [ ] Confirm Android install banner/prompt appears
- [ ] Confirm desktop install button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)