### PR TITLE
chore: add header inspection endpoint to diagnose mixed content

### DIFF
--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -49,6 +49,18 @@ api.version = "1.3.0-rc.22"
 api.description = "API documentation for LenoreChore"
 
 
+@api.get("/debug/headers", auth=None, include_in_schema=False)
+def debug_headers(request):
+    """Return all incoming HTTP headers and key proxy indicators. Remove before production."""
+    headers = {k: v for k, v in request.META.items() if k.startswith("HTTP_")}
+    return {
+        "headers": headers,
+        "is_secure": request.is_secure(),
+        "scheme": request.scheme,
+        "X-Forwarded-Proto": request.META.get("HTTP_X_FORWARDED_PROTO", "(not set)"),
+    }
+
+
 class VersionOut(Schema):
     """
     Schema to represent a Version.


### PR DESCRIPTION
## Summary

Adds a temporary unauthenticated endpoint at `/api/v2/debug/headers` that returns:
- All `HTTP_*` headers as seen by Django
- `request.is_secure()` — whether Django considers this an HTTPS request
- `request.scheme` — `http` or `https`
- The specific value of `X-Forwarded-Proto` (or `"(not set)"` if missing)

This is purely diagnostic — `include_in_schema=False` keeps it out of the API docs. **Remove before or immediately after 1.3 final release.**

## How to use

Hit `https://sandbox.danielleandjohn.love/api/v2/debug/headers` in a browser after deploying. Key things to check:
- Is `X-Forwarded-Proto` present and set to `https`?
- Is `is_secure` `true`?
- If `X-Forwarded-Proto` is `(not set)`, Traefik is not forwarding it and that is the root cause of mixed content

## Test plan

- [ ] Deploy to sandbox
- [ ] Hit `/api/v2/debug/headers` and confirm `X-Forwarded-Proto: https` and `is_secure: true`
- [ ] If header is missing, check Traefik middleware config for `X-Forwarded-Proto` passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)