### PR TITLE
fix: expand header inspection endpoint with additional proxy diagnostics

### DIFF
--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -57,7 +57,11 @@ def debug_headers(request):
         "headers": headers,
         "is_secure": request.is_secure(),
         "scheme": request.scheme,
-        "X-Forwarded-Proto": request.META.get("HTTP_X_FORWARDED_PROTO", "(not set)"),
+        "x_forwarded_proto": request.META.get("HTTP_X_FORWARDED_PROTO", "(not set)"),
+        "x_forwarded_host": request.META.get("HTTP_X_FORWARDED_HOST", "(not set)"),
+        "x_real_ip": request.META.get("HTTP_X_REAL_IP", "(not set)"),
+        "server_name": request.META.get("SERVER_NAME", "(not set)"),
+        "server_port": request.META.get("SERVER_PORT", "(not set)"),
     }
 
 


### PR DESCRIPTION
## Summary

Expands the `/api/v2/debug/headers` diagnostic endpoint to also return:
- `x_forwarded_host` — whether Traefik is forwarding the host header
- `x_real_ip` — the client IP as seen by Django
- `server_name` — the server name Django resolved
- `server_port` — the port Django sees (should be 443 if HTTPS is detected correctly)

This gives a complete picture of the Traefik → nginx → Django proxy chain to diagnose the remaining mixed-content issues.

> **Note:** This endpoint is temporary and will be removed before or immediately after the 1.3 final release.

## Test plan

- [ ] Deploy to sandbox
- [ ] Hit `https://sandbox.danielleandjohn.love/api/v2/debug/headers`
- [ ] Confirm `x_forwarded_proto` is `"https"` and `is_secure` is `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)