### PR TITLE
fix: repair PWA install prompt and add dismissal suppression

### DIFF
--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -48,22 +48,6 @@ api.version = "1.3.0-rc.24"
 api.description = "API documentation for LenoreChore"
 
 
-@api.get("/debug/headers", auth=None, include_in_schema=False)
-def debug_headers(request):
-    """Return all incoming HTTP headers and key proxy indicators. Remove before production."""
-    headers = {k: v for k, v in request.META.items() if k.startswith("HTTP_")}
-    return {
-        "headers": headers,
-        "is_secure": request.is_secure(),
-        "scheme": request.scheme,
-        "x_forwarded_proto": request.META.get("HTTP_X_FORWARDED_PROTO", "(not set)"),
-        "x_forwarded_host": request.META.get("HTTP_X_FORWARDED_HOST", "(not set)"),
-        "x_real_ip": request.META.get("HTTP_X_REAL_IP", "(not set)"),
-        "server_name": request.META.get("SERVER_NAME", "(not set)"),
-        "server_port": request.META.get("SERVER_PORT", "(not set)"),
-    }
-
-
 class VersionOut(Schema):
     """
     Schema to represent a Version.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -48,9 +48,7 @@
       >
         Install LenoreChore for a better experience!
         <template v-slot:actions>
-          <v-btn variant="text" @click="showInstallPrompt = false">
-            Not now
-          </v-btn>
+          <v-btn variant="text" @click="dismissInstall"> Not now </v-btn>
           <v-btn variant="text" @click="installApp"> Install </v-btn>
         </template>
       </v-snackbar>
@@ -157,11 +155,42 @@ const isInStandaloneMode =
   window.matchMedia("(display-mode: standalone)").matches ||
   navigator.standalone;
 
+const INSTALL_DISMISSED_KEY = "pwa-install-dismissed";
+const INSTALL_DISMISSED_DAYS = 7;
+
+function installDismissed() {
+  return !!localStorage.getItem(INSTALL_DISMISSED_KEY);
+}
+
+function setInstallDismissed() {
+  const expires = Date.now() + INSTALL_DISMISSED_DAYS * 24 * 60 * 60 * 1000;
+  localStorage.setItem(INSTALL_DISMISSED_KEY, String(expires));
+}
+
+function clearExpiredDismissal() {
+  const val = localStorage.getItem(INSTALL_DISMISSED_KEY);
+  if (val && Date.now() > Number(val)) {
+    localStorage.removeItem(INSTALL_DISMISSED_KEY);
+  }
+}
+
+const dismissInstall = () => {
+  showInstallPrompt.value = false;
+  setInstallDismissed();
+};
+
 const installApp = async () => {
   if (!deferredInstallPrompt) return;
-  deferredInstallPrompt.prompt();
-  const { outcome } = await deferredInstallPrompt.userChoice;
-  if (outcome === "accepted") {
+  try {
+    await deferredInstallPrompt.prompt();
+    const { outcome } = await deferredInstallPrompt.userChoice;
+    if (outcome === "dismissed") {
+      setInstallDismissed();
+    }
+  } catch (err) {
+    console.error("PWA install prompt failed:", err);
+    chorestore.showSnackbar("Install unavailable — try using the browser menu", "warning");
+  } finally {
     deferredInstallPrompt = null;
     showInstallPrompt.value = false;
   }
@@ -196,14 +225,21 @@ onMounted(async () => {
   window.addEventListener("offline", handleOffline);
 
   // Android/Chrome install prompt
+  clearExpiredDismissal();
   const handleInstallPrompt = (e) => {
     e.preventDefault();
     deferredInstallPrompt = e;
-    if (!isInStandaloneMode) {
+    if (!isInStandaloneMode && !installDismissed()) {
       showInstallPrompt.value = true;
     }
   };
   window.addEventListener("beforeinstallprompt", handleInstallPrompt);
+
+  const handleAppInstalled = () => {
+    deferredInstallPrompt = null;
+    showInstallPrompt.value = false;
+  };
+  window.addEventListener("appinstalled", handleAppInstalled);
 
   // iOS: show instructions once if not already installed
   if (isIOS && !isInStandaloneMode) {
@@ -220,6 +256,7 @@ onMounted(async () => {
     window.removeEventListener("online", handleOnline);
     window.removeEventListener("offline", handleOffline);
     window.removeEventListener("beforeinstallprompt", handleInstallPrompt);
+    window.removeEventListener("appinstalled", handleAppInstalled);
   });
 
   await checkSession();


### PR DESCRIPTION
## Summary

- **Fixes silent install failure**: `prompt()` was not being awaited before reading `userChoice`, causing a race condition where the native install dialog never appeared
- **Surfaces errors**: wraps `prompt()` in try/catch; shows a snackbar if the prompt throws (e.g. event already consumed by Chrome's mini-infobar)
- **Cleans up reliably**: `finally` block always nulls `deferredInstallPrompt` and hides the banner regardless of outcome
- **Handles Chrome's own install button**: adds `appinstalled` listener to clean up state when Chrome installs via the address-bar button
- **7-day dismissal suppression**: clicking "Not now" or dismissing the native prompt stores an expiry timestamp in localStorage; banner won't re-appear until it expires; stale entries are cleared automatically on mount

## Test plan

- [ ] Deploy to sandbox (`sandbox.danielleandjohn.love`)
- [ ] Open in fresh incognito window — install banner should appear
- [ ] Click **Install** — Chrome install dialog should appear
- [ ] Click **Not now** — banner dismisses and does not reappear on reload
- [ ] After 7 days (or clear localStorage) — banner reappears
- [ ] Test on Android Chrome — install banner and prompt should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)