### PR TITLE
fix: pre-release UI tweaks for 1.3

### DIFF
--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "bundler",
     "paths": {
       "@/*": [
-        "src/*"
+        "./src/*"
       ]
     },
     "lib": [

--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -1,19 +1,17 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "module": "esnext",
-    "baseUrl": "./",
-    "moduleResolution": "node",
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "paths": {
       "@/*": [
         "src/*"
       ]
     },
     "lib": [
-      "esnext",
-      "dom",
-      "dom.iterable",
-      "scripthost"
+      "ESNext",
+      "DOM",
+      "DOM.Iterable"
     ]
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,14 +1,13 @@
 {
   "name": "frontend",
-  "version": "1.3.0-rc.18",
+  "version": "1.3.0-rc.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.3.0-rc.18",
+      "version": "1.3.0-rc.25",
       "dependencies": {
-        "@bhplugin/vue3-datatable": "^1.1.4",
         "@fontsource/roboto": "^5.2.10",
         "@headlessui/vue": "^1.7.22",
         "@heroicons/vue": "^2.1.3",
@@ -1699,17 +1698,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@bhplugin/vue3-datatable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@bhplugin/vue3-datatable/-/vue3-datatable-1.1.4.tgz",
-      "integrity": "sha512-MScegPKH+jD92zeFCGgAwfBC6DWr+JIgfrObWdbN/5fKonxM1U707vuD6Kcglx1WhwDgTpu3KIvjSPuxRIipYg==",
-      "dependencies": {
-        "vue": "^3.2.37"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/bhaveshpatel200"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,6 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
-    "@bhplugin/vue3-datatable": "^1.1.4",
     "@fontsource/roboto": "^5.2.10",
     "@headlessui/vue": "^1.7.22",
     "@heroicons/vue": "^2.1.3",

--- a/frontend/src/components/ChoreCard.vue
+++ b/frontend/src/components/ChoreCard.vue
@@ -72,8 +72,8 @@
 
     <v-expand-transition>
       <div v-if="expand">
-        <v-container theme="dark" class="bg-secondary">
-          <v-row dense class="bg-secondary">
+        <v-container class="bg-chorePanel">
+          <v-row dense class="bg-chorePanel">
             <v-col>
               <v-text-field
                 v-model="localchore.chore_name"
@@ -82,7 +82,7 @@
               ></v-text-field>
             </v-col>
           </v-row>
-          <v-row dense class="bg-secondary">
+          <v-row dense class="bg-chorePanel">
             <v-col>
               <VueDatePicker
                 v-model="localchore.lastCompleted"
@@ -134,7 +134,7 @@
               <v-checkbox
                 v-model="localchore.active_months"
                 label="Jan"
-                color="accent"
+                color="primary"
                 hide-details
                 :value="1"
                 @update:modelValue="changeDetected()"
@@ -144,7 +144,7 @@
               <v-checkbox
                 v-model="localchore.active_months"
                 label="Feb"
-                color="accent"
+                color="primary"
                 hide-details
                 :value="2"
                 @update:modelValue="changeDetected()"
@@ -154,7 +154,7 @@
               <v-checkbox
                 v-model="localchore.active_months"
                 label="Mar"
-                color="accent"
+                color="primary"
                 hide-details
                 :value="3"
                 @update:modelValue="changeDetected()"
@@ -164,7 +164,7 @@
               <v-checkbox
                 v-model="localchore.active_months"
                 label="Apr"
-                color="accent"
+                color="primary"
                 hide-details
                 :value="4"
                 @update:modelValue="changeDetected()"
@@ -176,7 +176,7 @@
               <v-checkbox
                 v-model="localchore.active_months"
                 label="May"
-                color="accent"
+                color="primary"
                 hide-details
                 :value="5"
                 @update:modelValue="changeDetected()"
@@ -186,7 +186,7 @@
               <v-checkbox
                 v-model="localchore.active_months"
                 label="Jun"
-                color="accent"
+                color="primary"
                 hide-details
                 :value="6"
                 @update:modelValue="changeDetected()"
@@ -196,7 +196,7 @@
               <v-checkbox
                 v-model="localchore.active_months"
                 label="Jul"
-                color="accent"
+                color="primary"
                 hide-details
                 :value="7"
                 @update:modelValue="changeDetected()"
@@ -206,7 +206,7 @@
               <v-checkbox
                 v-model="localchore.active_months"
                 label="Aug"
-                color="accent"
+                color="primary"
                 hide-details
                 :value="8"
                 @update:modelValue="changeDetected()"
@@ -218,7 +218,7 @@
               <v-checkbox
                 v-model="localchore.active_months"
                 label="Sep"
-                color="accent"
+                color="primary"
                 hide-details
                 :value="9"
                 @update:modelValue="changeDetected()"
@@ -228,7 +228,7 @@
               <v-checkbox
                 v-model="localchore.active_months"
                 label="Oct"
-                color="accent"
+                color="primary"
                 hide-details
                 :value="10"
                 @update:modelValue="changeDetected()"
@@ -238,7 +238,7 @@
               <v-checkbox
                 v-model="localchore.active_months"
                 label="Nov"
-                color="accent"
+                color="primary"
                 hide-details
                 :value="11"
                 @update:modelValue="changeDetected()"
@@ -248,7 +248,7 @@
               <v-checkbox
                 v-model="localchore.active_months"
                 label="Dec"
-                color="accent"
+                color="primary"
                 hide-details
                 :value="12"
                 @update:modelValue="changeDetected()"
@@ -319,10 +319,10 @@
     </v-expand-transition>
     <v-expand-transition>
       <div v-if="localchore.history">
-        <v-container class="bg-secondary" theme="dark">
+        <v-container class="bg-chorePanel">
           <v-row dense>
             <v-col>
-              <v-table class="bg-secondary">
+              <v-table class="bg-chorePanel">
                 <thead>
                   <tr>
                     <th class="text-left">Date</th>
@@ -463,9 +463,7 @@ const callResetChore = async () => {
   localchore.value.duedays = props.chore.duedays;
   localchore.value.unit = props.chore.unit;
   localchore.value.intervalNumber = props.chore.intervalNumber;
-  localchore.value.active_months = props.chore.active_months.map(
-    month => month.id,
-  );
+  localchore.value.active_months = deepCopy(props.chore.active_months);
   localchore.value.nextDue = props.chore.nextDue;
   localchore.value.lastCompleted = props.chore.lastCompleted;
   localchore.value.effort = props.chore.effort;

--- a/frontend/src/components/ChoreGraphs.vue
+++ b/frontend/src/components/ChoreGraphs.vue
@@ -1,6 +1,6 @@
 <template>
-  <div style="height: 400px" v-if="!isLoading">
-    <v-container fluid
+  <div v-if="!isLoading" style="height: 400px">
+    <v-container fluid class="bg-secondary"
       ><v-row
         ><v-col cols="3" class="text-right"
           ><v-btn
@@ -22,7 +22,7 @@
             :disabled="!historystore.graph.week"
           ></v-btn></v-col></v-row
     ></v-container>
-    <Bar id="my-chart-id" :options="chartOptions" :data="weeklyTotals" />
+    <Bar id="my-chart-id" :options="chartOptions" :data="weeklyTotals" :plugins="chartPlugins" />
   </div>
 </template>
 <script setup>
@@ -38,8 +38,11 @@ import {
 } from "chart.js";
 import { useWeeklyTotals } from "@/composables/historyItemsComposable";
 import { useHistoryItemsStore } from "@/stores/historyitems";
+import { useThemeStore } from "@/stores/theme";
+import { computed } from "vue";
 
 const historystore = useHistoryItemsStore();
+const themeStore = useThemeStore();
 const { weeklyTotals, isLoading } = useWeeklyTotals();
 
 ChartJS.register(
@@ -51,20 +54,46 @@ ChartJS.register(
   LinearScale,
 );
 
-const chartOptions = {
-  responsive: true,
-  indexAxis: "x",
-  title: {
-    display: true,
-    text: "Graphs",
-  },
-  plugins: {
-    legend: {
-      position: "bottom",
+const chartPlugins = computed(() => {
+  if (!themeStore.isDark) return [];
+  return [{
+    id: "lightBackground",
+    beforeDraw: (chart) => {
+      const ctx = chart.canvas.getContext("2d");
+      ctx.save();
+      ctx.globalCompositeOperation = "destination-over";
+      ctx.fillStyle = "#EEEEEE";
+      ctx.fillRect(0, 0, chart.width, chart.height);
+      ctx.restore();
     },
-  },
-  maintainAspectRatio: false,
-};
+  }];
+});
+
+const chartOptions = computed(() => {
+  const textColor = themeStore.isDark ? "#333333" : undefined;
+  const gridColor = themeStore.isDark ? "rgba(0,0,0,0.1)" : undefined;
+  return {
+    responsive: true,
+    indexAxis: "x",
+    plugins: {
+      legend: {
+        position: "bottom",
+        labels: { color: textColor },
+      },
+    },
+    scales: {
+      x: {
+        ticks: { color: textColor },
+        grid: { color: gridColor },
+      },
+      y: {
+        ticks: { color: textColor },
+        grid: { color: gridColor },
+      },
+    },
+    maintainAspectRatio: false,
+  };
+});
 
 const increaseWeek = () => {
   historystore.graph.week += 1;

--- a/frontend/src/components/HistoryTable.vue
+++ b/frontend/src/components/HistoryTable.vue
@@ -1,54 +1,48 @@
 <template>
-  <vue3-datatable
-    :rows="historyItems ? historyItems.items : []"
-    :columns="columns"
+  <v-data-table-server
+    :headers="headers"
+    :items="historyItems ? historyItems.items : []"
+    :items-length="historyItems ? historyItems.total_records : 0"
     :loading="isLoading"
-    :totalRows="historyItems ? historyItems.total_records : 0"
-    :isServerMode="true"
-    :pageSize="historystore.pageinfo.page_size"
-    :stickyHeader="true"
-    noDataContent="No history"
-    search=""
-    ref="history_table"
+    :items-per-page="historystore.pageinfo.page_size"
+    :items-per-page-options="[{ value: 15, title: '15' }]"
+    density="compact"
+    fixed-header
     height="600px"
-    skin="bh-table-striped bh-table-compact"
-    :pageSizeOptions="[5]"
-    :showPageSize="false"
-    paginationInfo="Showing {0} to {1} of {2} items"
-    class="alt-pagination"
-    @change="pageChanged"
+    no-data-text="No history"
+    class="striped-table"
+    @update:options="pageChanged"
   >
-    <template #completed_by.email="row">
+    <template #item.completed_by="{ item }">
       <span>{{
-        row.value.completed_by.fullname == " "
-          ? row.value.completed_by.email
-          : row.value.completed_by.fullname
+        item.completed_by.fullname?.trim()
+          ? item.completed_by.fullname
+          : item.completed_by.email
       }}</span>
     </template>
-  </vue3-datatable>
+  </v-data-table-server>
 </template>
+
 <script setup>
 import { useHistoryItems } from "@/composables/historyItemsComposable";
-import Vue3Datatable from "@bhplugin/vue3-datatable";
-import "@bhplugin/vue3-datatable/dist/style.css";
-import { ref } from "vue";
 import { useHistoryItemsStore } from "@/stores/historyitems";
 
 const historystore = useHistoryItemsStore();
 const { historyItems, isLoading } = useHistoryItems();
-const columns = ref([
-  { field: "id", title: "ID", isUnique: true, hide: true },
-  { field: "completed_date", title: "Date", type: "date", width: "120px" },
-  { field: "chore.chore_name", title: "Chore", width: "100px" },
-  { field: "completed_by.email", title: "Completed By", width: "100px" },
-]);
-const pageChanged = data => {
-  historystore.pageinfo.page = data.current_page;
+
+const headers = [
+  { title: "Date", key: "completed_date", width: "120px", sortable: false },
+  { title: "Chore", key: "chore.chore_name", width: "100px", sortable: false },
+  { title: "Completed By", key: "completed_by", width: "100px", sortable: false },
+];
+
+const pageChanged = ({ page }) => {
+  historystore.pageinfo.page = page;
 };
 </script>
-<style>
-.alt-pagination .bh-pagination .bh-page-item {
-  background-color: #2196f3;
-  color: white;
+
+<style scoped>
+.striped-table :deep(tbody tr:nth-child(odd)) {
+  background-color: rgba(0, 0, 0, 0.09);
 }
 </style>

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -25,6 +25,7 @@ const myCustomLightTheme = {
     user2: "#3F51B5",
     user3: "#009688",
     user4: "#CDDC39",
+    chorePanel: "#E0E0E0",
   },
 };
 
@@ -48,6 +49,7 @@ const myCustomDarkTheme = {
     user2: "#3F51B5",
     user3: "#009688",
     user4: "#CDDC39",
+    chorePanel: "#424242",
   },
 };
 


### PR DESCRIPTION
## Summary

- **ChoreCard tray background**: theme-aware grey via new `chorePanel` Vuetify color (`#E0E0E0` light / `#424242` dark); removed forced `theme="dark"` so form fields follow the active theme naturally
- **ChoreCard reset bug**: fixed reset button deselecting all months — `.map(m => m.id)` was being called on an already-integer array, returning `[undefined...]`; replaced with `deepCopy()`
- **ChoreCard month checkboxes**: color changed from `accent` (yellow) to `primary` for better contrast on the new grey tray
- **HistoryTable**: replaced `vue3-datatable` with native Vuetify `v-data-table-server`; uninstalled `@bhplugin/vue3-datatable`; added alternating row stripe (9% black overlay)
- **ChoreGraphs dark mode**: canvas background plugin paints `#EEEEEE` directly on the chart canvas in dark mode so legend, axis labels, and gridlines are all readable; axis/legend text forced to `#333333`; week navigation bar uses `bg-secondary`

## Test plan

- [ ] Deploy to sandbox
- [ ] Verify chore slide-out tray is light grey in light mode, dark grey in dark mode
- [ ] Verify reset button restores month checkboxes correctly
- [ ] Verify history table pagination works, rows alternate
- [ ] Verify graph is readable in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)