### PR TITLE
chore: parse version tag to determine release type for Reddit post

### DIFF
--- a/scripts/post_to_reddit.py
+++ b/scripts/post_to_reddit.py
@@ -9,13 +9,24 @@ FLAIR_ID_MAP = {
 
 
 def main():
-    tag = os.environ["COMMIT_TAG"].lower()
+    raw_tag = os.environ["COMMIT_TAG"].lstrip("vV")
     version = Path("scripts/version.txt").read_text().strip()
     changelog = os.environ["RELEASE_NOTES"]
 
-    flair_id = FLAIR_ID_MAP.get(tag)
+    try:
+        major, minor, patch = (int(x) for x in raw_tag.split(".")[:3])
+    except ValueError:
+        print(f"⚠️ Could not parse version tag '{raw_tag}', skipping Reddit post.")
+        return
+
+    if patch != 0:
+        print(f"⚠️ Patch release '{raw_tag}', skipping Reddit post.")
+        return
+
+    release_type = "major" if minor == 0 else "minor"
+    flair_id = FLAIR_ID_MAP.get(release_type)
     if not flair_id:
-        print(f"⚠️ Unknown tag '{tag}', skipping Reddit post.")
+        print(f"⚠️ No flair configured for release type '{release_type}', skipping Reddit post.")
         return
 
     reddit = praw.Reddit(


### PR DESCRIPTION
## Summary

The Reddit announce script was doing `FLAIR_ID_MAP.get("v1.3.0")` — looking up the full version tag — but the map only has `"major"` and `"minor"` as keys. Every release was hitting the unknown tag branch and skipping the post.

Fix: strip the `v` prefix, parse `major.minor.patch`, skip if patch ≠ 0, then derive `"major"` (minor == 0) or `"minor"` (minor > 0) to look up the flair.

## Test plan

- [ ] Merge this fix
- [ ] Re-trigger the announce workflow against `v1.3.0` to post the release announcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)