### PR TITLE
chore: fix COMMIT_TAG missing inputs.tag fallback for workflow_dispatch

### DIFF
--- a/.github/workflows/announce_reddit.yml
+++ b/.github/workflows/announce_reddit.yml
@@ -1,6 +1,11 @@
 name: Announce on Reddit
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to announce (e.g. v1.3.0)"
+        required: true
   release:
     types: [published]
 
@@ -8,8 +13,8 @@ permissions:
   contents: read
 
 env:
-  VERSION: ${{ github.event.release.tag_name }}
-  IS_PRERELEASE: ${{ github.event.release.prerelease }}
+  VERSION: ${{ github.event.release.tag_name || inputs.tag }}
+  IS_PRERELEASE: ${{ github.event.release.prerelease || 'false' }}
 
 jobs:
   reddit:

--- a/.github/workflows/announce_reddit.yml
+++ b/.github/workflows/announce_reddit.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Post to Reddit
         if: steps.version_parts.outputs.type == 'release'
         env:
-          COMMIT_TAG: ${{ github.event.release.tag_name }}
+          COMMIT_TAG: ${{ github.event.release.tag_name || inputs.tag }}
           RELEASE_NOTES: ${{ steps.release_notes.outputs.result }}
           REDDIT_CLIENT_ID: ${{ secrets.REDDIT_CLIENT_ID }}
           REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}

--- a/scripts/post_to_reddit.py
+++ b/scripts/post_to_reddit.py
@@ -9,13 +9,24 @@ FLAIR_ID_MAP = {
 
 
 def main():
-    tag = os.environ["COMMIT_TAG"].lower()
+    raw_tag = os.environ["COMMIT_TAG"].lstrip("vV")
     version = Path("scripts/version.txt").read_text().strip()
     changelog = os.environ["RELEASE_NOTES"]
 
-    flair_id = FLAIR_ID_MAP.get(tag)
+    try:
+        major, minor, patch = (int(x) for x in raw_tag.split(".")[:3])
+    except ValueError:
+        print(f"⚠️ Could not parse version tag '{raw_tag}', skipping Reddit post.")
+        return
+
+    if patch != 0:
+        print(f"⚠️ Patch release '{raw_tag}', skipping Reddit post.")
+        return
+
+    release_type = "major" if minor == 0 else "minor"
+    flair_id = FLAIR_ID_MAP.get(release_type)
     if not flair_id:
-        print(f"⚠️ Unknown tag '{tag}', skipping Reddit post.")
+        print(f"⚠️ No flair configured for release type '{release_type}', skipping Reddit post.")
         return
 
     reddit = praw.Reddit(


### PR DESCRIPTION
COMMIT_TAG env var in the Post to Reddit step was not falling back to `inputs.tag` when triggered manually, causing an empty tag and skipping the post.