### PR TITLE
fix: exclude /admin from SW navigateFallback without trailing slash

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -76,7 +76,7 @@ export default defineConfig({
         navigateFallback: "index.html",
         navigateFallbackDenylist: [
           /^\/api\//,
-          /^\/admin\//,
+          /^\/admin/,
           /^\/_allauth\//,
         ],
         runtimeCaching: [


### PR DESCRIPTION
## Root Cause

The Workbox `navigateFallbackDenylist` had `/^\/admin\//` — requiring a trailing slash. Navigating to `/admin` (no slash) didn't match, so the service worker served `index.html` (the SPA fallback) instead of letting the request reach Django's admin redirect.

## Fix

Widened the regex from `/^\/admin\//` to `/^\/admin/` so it matches both `/admin` and `/admin/*`.

## Test plan

- [ ] Clicking the Admin link in the nav menu navigates to the Django admin login page
- [ ] `/admin/` (with trailing slash) still reaches Django admin
- [ ] Other SW routing (offline queue, API caching) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)