### PR TITLE
fix: use canonical /admin/ URL for Django admin link

### DIFF
--- a/frontend/src/views/AppNavigation.vue
+++ b/frontend/src/views/AppNavigation.vue
@@ -76,7 +76,7 @@
       <v-list>
         <v-list-item
           as="a"
-          href="/admin"
+          href="/admin/"
           v-if="store.isAdmin"
           prepend-icon="mdi-security"
         >


### PR DESCRIPTION
## Root Cause

`href="/admin"` (no trailing slash) causes Django to issue a 301 redirect to `/admin/`. The SW denylist pattern `/^\/admin\//` only matched the redirected URL, not the original request — so the SW intercepted the initial navigation to `/admin`, served `index.html`, and the `isPageReload` router guard redirected back to `/`.

This was masked on desktop (possibly by bfcache or slightly different SW lifecycle), but consistently reproduced on mobile.

## Fix

Change `href="/admin"` → `href="/admin/"`. This hits Django's canonical admin URL directly with no redirect, and `/admin/` matches the SW denylist immediately.

The previous PR (#52) widened the SW denylist regex to also cover the no-trailing-slash form as a belt-and-suspenders fix.

## Test plan

- [ ] Admin link works on mobile (navigates to Django admin login)
- [ ] Admin link works on desktop
- [ ] No regression on other nav items

🤖 Generated with [Claude Code](https://claude.com/claude-code)