### PR TITLE
fix: clear SW and TanStack Query caches on version-mismatch reload

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -90,7 +90,25 @@ import { useTheme } from "vuetify";
 import axios from "axios";
 import { version as appVersion } from "../package.json";
 
-const reloadPage = () => {
+const reloadPage = async () => {
+  // Clear TanStack Query cache so stale data isn't served after reload
+  queryClient.clear();
+
+  // Clear all Workbox/SW caches so the new assets are fetched from the network
+  if ("caches" in window) {
+    const cacheNames = await caches.keys();
+    await Promise.all(cacheNames.map(name => caches.delete(name)));
+  }
+
+  // Tell the waiting SW (if any) to take control immediately, then reload
+  if ("serviceWorker" in navigator) {
+    const registration = await navigator.serviceWorker.getRegistration();
+    if (registration?.waiting) {
+      registration.waiting.postMessage({ type: "SKIP_WAITING" });
+      await new Promise(resolve => navigator.serviceWorker.addEventListener("controllerchange", resolve, { once: true }));
+    }
+  }
+
   window.location.reload();
 };
 


### PR DESCRIPTION
## Problem

Clicking **Refresh** on the update banner called `window.location.reload()`. Because Workbox's SW cache served the old assets, the page appeared to reload but still ran the previous version — the banner would reappear on the next version check.

## Fix

`reloadPage` is now async and does three things before reloading:

1. **`queryClient.clear()`** — discards all in-memory TanStack Query data so stale API responses are not carried over
2. **`caches.keys()` + `caches.delete()`** — deletes every Workbox cache bucket so the network is hit for fresh JS/CSS/HTML on reload
3. **SW `SKIP_WAITING`** — if a new service worker is already waiting (common on PWA auto-update), sends `SKIP_WAITING` and waits for `controllerchange` before reloading so the new SW is in control immediately

## Test plan

- [ ] Trigger a version mismatch (deploy a new version while app is open)
- [ ] Click Refresh on the update banner
- [ ] Verify the app loads the new version (version in nav matches deployed version)
- [ ] Verify the update banner does not reappear after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)