### PR TITLE
fix: add Back to Site to admin usermenu for mobile visibility

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -284,6 +284,15 @@ JAZZMIN_SETTINGS = {
             "new_window": False,
         },
     ],
+    # Links in the user profile dropdown — visible on both desktop and mobile
+    "usermenu_links": [
+        {
+            "name": "Back to Site",
+            "url": "/",
+            "icon": "fas fa-home",
+            "new_window": False,
+        },
+    ],
 }
 
 JAZZMIN_UI_TWEAKS = {


### PR DESCRIPTION
## Problem

The **Back to Site** link in `topmenu_links` is hidden on mobile because Jazzmin's top navbar collapses via Bootstrap's responsive behaviour — the nav items become inaccessible without a separate toggle.

## Fix

Added the same link to `usermenu_links` (the profile/avatar dropdown in the top-right corner). This dropdown is always rendered and accessible on both mobile and desktop, so the link is never hidden.

The `topmenu_links` entry is kept as-is so it remains in its familiar position on desktop.

## Test plan

- [ ] On mobile: tap the user avatar/profile icon in the admin top-right → Back to Site appears in the dropdown
- [ ] On desktop: Back to Site still visible in the top navbar as before
- [ ] Clicking Back to Site on both platforms navigates to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)