### PR TITLE
feat: add SSE real-time sync for multi-user invalidation

### DIFF
--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -655,6 +655,7 @@ def toggle_vacation(request):
             chore.save()
     invalidate("options")
     invalidate_pattern("chores:*")
+    invalidate("areas")
     notify("options")
     notify("chores")
     return {"success": True}
@@ -736,6 +737,7 @@ def create_chore(request, payload: ChoreIn):
     chore.active_months.set(active_months)
 
     invalidate_pattern("chores:*")
+    invalidate("areas")
     notify("chores")
     return {"id": chore.id}
 
@@ -1189,6 +1191,7 @@ def update_chore(request, chore_id: int, payload: ChoreIn):
     chore.effort = payload.effort
     chore.save()
     invalidate_pattern("chores:*")
+    invalidate("areas")
     notify("chores")
     return {"success": True}
 
@@ -1214,6 +1217,7 @@ def toggle_chore(request, chore_id: int, payload: TogglActive):
     chore.status = payload.status
     chore.save()
     invalidate_pattern("chores:*")
+    invalidate("areas")
     notify("chores")
     return {"success": True}
 
@@ -1239,6 +1243,7 @@ def snooze_chore(request, chore_id: int, payload: SnoozeChore):
     chore.nextDue = payload.nextDue
     chore.save()
     invalidate_pattern("chores:*")
+    invalidate("areas")
     notify("chores")
     return {"success": True}
 
@@ -1311,6 +1316,7 @@ def complete_chore(request, chore_id: int, payload: CompleteChore):
         chore=chore,
     )
     invalidate_pattern("chores:*", "weeklytotals:*")
+    invalidate("areas")
     notify("chores")
     notify("history")
     return {"success": True}
@@ -1436,6 +1442,7 @@ def delete_chore(request, chore_id: int):
     chore = get_object_or_404(Chore, id=chore_id)
     chore.delete()
     invalidate_pattern("chores:*")
+    invalidate("areas")
     notify("chores")
     return {"success": True}
 

--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -1,5 +1,6 @@
 from ninja import NinjaAPI, Schema, Router, Query
 from ninja.security import django_auth
+from backend.sse import notify
 from api.models import (
     CustomUser,
     AreaGroup,
@@ -654,6 +655,8 @@ def toggle_vacation(request):
             chore.save()
     invalidate("options")
     invalidate_pattern("chores:*")
+    notify("options")
+    notify("chores")
     return {"success": True}
 
 
@@ -675,6 +678,7 @@ def create_areagroup(request, payload: AreaGroupIn):
     """
     areagroup = AreaGroup.objects.create(**payload.dict())
     invalidate("areagroups")
+    notify("areagroups")
     return {"id": areagroup.id}
 
 
@@ -696,6 +700,7 @@ def create_area(request, payload: AreaIn):
     """
     area = Area.objects.create(**payload.dict())
     invalidate("areas", "areagroups")
+    notify("areas")
     return {"id": area.id}
 
 
@@ -731,6 +736,7 @@ def create_chore(request, payload: ChoreIn):
     chore.active_months.set(active_months)
 
     invalidate_pattern("chores:*")
+    notify("chores")
     return {"id": chore.id}
 
 
@@ -758,6 +764,8 @@ def create_historyitem(request, payload: HistoryItemIn):
         chore_id=payload.chore_id,
     )
     invalidate_pattern("chores:*", "weeklytotals:*")
+    notify("chores")
+    notify("history")
     return {"id": historyitem.id}
 
 
@@ -1120,6 +1128,7 @@ def update_areagroup(request, areagroup_id: int, payload: AreaGroupIn):
     areagroup.group_color = payload.group_color
     areagroup.save()
     invalidate("areagroups")
+    notify("areagroups")
     return {"success": True}
 
 
@@ -1146,6 +1155,7 @@ def update_area(request, area_id: int, payload: AreaIn):
     area.group_id = payload.group_id
     area.save()
     invalidate("areas", "areagroups")
+    notify("areas")
     return {"success": True}
 
 
@@ -1179,6 +1189,7 @@ def update_chore(request, chore_id: int, payload: ChoreIn):
     chore.effort = payload.effort
     chore.save()
     invalidate_pattern("chores:*")
+    notify("chores")
     return {"success": True}
 
 
@@ -1203,6 +1214,7 @@ def toggle_chore(request, chore_id: int, payload: TogglActive):
     chore.status = payload.status
     chore.save()
     invalidate_pattern("chores:*")
+    notify("chores")
     return {"success": True}
 
 
@@ -1227,6 +1239,7 @@ def snooze_chore(request, chore_id: int, payload: SnoozeChore):
     chore.nextDue = payload.nextDue
     chore.save()
     invalidate_pattern("chores:*")
+    notify("chores")
     return {"success": True}
 
 
@@ -1251,6 +1264,7 @@ def claim_chore(request, chore_id: int, payload: ClaimChore):
     chore.assignee_id = payload.assignee_id
     chore.save()
     invalidate_pattern("chores:*")
+    notify("chores")
     return {"success": True}
 
 
@@ -1297,6 +1311,8 @@ def complete_chore(request, chore_id: int, payload: CompleteChore):
         chore=chore,
     )
     invalidate_pattern("chores:*", "weeklytotals:*")
+    notify("chores")
+    notify("history")
     return {"success": True}
 
 
@@ -1323,6 +1339,8 @@ def update_historyitem(request, historyitem_id: int, payload: HistoryItemIn):
     historyitem.chore_id = payload.chore_id
     historyitem.save()
     invalidate_pattern("chores:*", "weeklytotals:*")
+    notify("chores")
+    notify("history")
     return {"success": True}
 
 
@@ -1349,6 +1367,7 @@ def update_option(request, option_id: int, payload: OptionIn):
     option.high_thresh = payload.high_thresh
     option.save()
     invalidate("options")
+    notify("options")
     return {"success": True}
 
 
@@ -1371,6 +1390,7 @@ def delete_areagroup(request, areagroup_id: int):
     areagroup = get_object_or_404(AreaGroup, id=areagroup_id)
     areagroup.delete()
     invalidate("areagroups")
+    notify("areagroups")
     return {"success": True}
 
 
@@ -1393,6 +1413,7 @@ def delete_area(request, area_id: int):
     area = get_object_or_404(Area, id=area_id)
     area.delete()
     invalidate("areas", "areagroups")
+    notify("areas")
     return {"success": True}
 
 
@@ -1415,6 +1436,7 @@ def delete_chore(request, chore_id: int):
     chore = get_object_or_404(Chore, id=chore_id)
     chore.delete()
     invalidate_pattern("chores:*")
+    notify("chores")
     return {"success": True}
 
 
@@ -1437,6 +1459,8 @@ def delete_historyitem(request, historyitem_id: int):
     historyitem = get_object_or_404(HistoryItem, id=historyitem_id)
     historyitem.delete()
     invalidate_pattern("chores:*", "weeklytotals:*")
+    notify("chores")
+    notify("history")
     return {"success": True}
 
 

--- a/backend/backend/sse.py
+++ b/backend/backend/sse.py
@@ -1,0 +1,60 @@
+import json
+import os
+import time
+
+from django.http import HttpResponse, StreamingHttpResponse
+
+
+def _get_redis():
+    redis_url = os.environ.get("REDIS_URL")
+    if not redis_url:
+        return None
+    try:
+        import redis
+
+        return redis.from_url(redis_url)
+    except Exception:
+        return None
+
+
+def notify(event_type):
+    """Publish a cache-invalidation event to all connected SSE clients."""
+    r = _get_redis()
+    if r:
+        try:
+            r.publish("lenore:events", json.dumps({"type": event_type}))
+        except Exception:
+            pass
+
+
+def sse_view(request):
+    if not request.user.is_authenticated:
+        return HttpResponse(status=401)
+
+    def event_stream():
+        r = _get_redis()
+        if r:
+            pubsub = r.pubsub()
+            pubsub.subscribe("lenore:events")
+            try:
+                yield 'data: {"type":"connected"}\n\n'
+                while True:
+                    message = pubsub.get_message(timeout=25)
+                    if message and message["type"] == "message":
+                        yield f"data: {message['data'].decode()}\n\n"
+                    else:
+                        yield ": keepalive\n\n"
+            except GeneratorExit:
+                pubsub.unsubscribe()
+                pubsub.close()
+        else:
+            # No Redis — keepalives only; cross-user broadcast not available
+            yield 'data: {"type":"connected"}\n\n'
+            while True:
+                time.sleep(25)
+                yield ": keepalive\n\n"
+
+    response = StreamingHttpResponse(event_stream(), content_type="text/event-stream")
+    response["Cache-Control"] = "no-cache"
+    response["X-Accel-Buffering"] = "no"
+    return response

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -17,10 +17,12 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from .api import api
+from .sse import sse_view
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v2/', api.urls),
+    path('api/v2/events/', sse_view),
     path('api/', include('api.urls')),
     path('_allauth/', include('allauth.headless.urls')),
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,3 +18,4 @@ django-q2==1.6.2
 arrow==1.3.0
 django-allauth[headless]==65.3.1
 django-redis==5.4.0
+gevent==24.2.1

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -84,6 +84,7 @@ import { VueQueryDevtools } from "@tanstack/vue-query-devtools";
 import { useVersion } from "@/composables/versionComposable";
 import { useSync } from "@/composables/syncComposable";
 import { usePrefetch } from "@/composables/prefetchComposable";
+import { useSSE } from "@/composables/sseComposable";
 import { useQueryClient } from "@tanstack/vue-query";
 import { useRouter } from "vue-router";
 import { useTheme } from "vuetify";
@@ -122,6 +123,7 @@ const queryClient = useQueryClient();
 const { prefetchVersion, version } = useVersion();
 const { replayQueue } = useSync();
 const { prefetchCriticalData } = usePrefetch();
+const { connect: sseConnect, disconnect: sseDisconnect } = useSSE();
 
 const showBanner = ref(false);
 const showInstallPrompt = ref(false);
@@ -235,9 +237,11 @@ onMounted(async () => {
   const handleOnline = () => {
     offlineStore.setOnline(true);
     replayQueue();
+    if (userstore.isLoggedIn) sseConnect();
   };
   const handleOffline = () => {
     offlineStore.setOnline(false);
+    sseDisconnect();
   };
   window.addEventListener("online", handleOnline);
   window.addEventListener("offline", handleOffline);
@@ -275,6 +279,7 @@ onMounted(async () => {
     window.removeEventListener("offline", handleOffline);
     window.removeEventListener("beforeinstallprompt", handleInstallPrompt);
     window.removeEventListener("appinstalled", handleAppInstalled);
+    sseDisconnect();
   });
 
   await checkSession();
@@ -284,6 +289,7 @@ onMounted(async () => {
   // Pre-warm critical API data in TanStack Query + Workbox cache
   if (userstore.isLoggedIn) {
     prefetchCriticalData();
+    sseConnect();
   }
 
   // Replay any mutations that were queued in a previous offline session
@@ -301,8 +307,10 @@ watch(
   (isLoggedIn) => {
     if (!isLoggedIn) {
       queryClient.clear();
+      sseDisconnect();
     } else {
       prefetchCriticalData();
+      sseConnect();
     }
   }
 );

--- a/frontend/src/composables/sseComposable.js
+++ b/frontend/src/composables/sseComposable.js
@@ -2,7 +2,7 @@ import { useQueryClient } from "@tanstack/vue-query";
 import { useOfflineStore } from "@/stores/offline";
 
 const QUERY_KEYS = {
-  chores: ["chores"],
+  chores: ["chores", "areas"],
   areas: ["areas", "areagroups"],
   areagroups: ["areagroups"],
   options: ["options"],

--- a/frontend/src/composables/sseComposable.js
+++ b/frontend/src/composables/sseComposable.js
@@ -1,0 +1,64 @@
+import { useQueryClient } from "@tanstack/vue-query";
+import { useOfflineStore } from "@/stores/offline";
+
+const QUERY_KEYS = {
+  chores: ["chores"],
+  areas: ["areas", "areagroups"],
+  areagroups: ["areagroups"],
+  options: ["options"],
+  history: ["historyitems"],
+  users: ["users"],
+};
+
+export function useSSE() {
+  const queryClient = useQueryClient();
+  const offlineStore = useOfflineStore();
+
+  let source = null;
+  let reconnectTimer = null;
+  let reconnectDelay = 2000;
+
+  function connect() {
+    if (offlineStore.isOffline) return;
+    if (source && source.readyState !== EventSource.CLOSED) return;
+
+    source = new EventSource("/api/v2/events/");
+
+    source.addEventListener("message", (event) => {
+      reconnectDelay = 2000;
+      let data;
+      try {
+        data = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+      if (data.type === "connected") return;
+
+      const keys = QUERY_KEYS[data.type];
+      if (keys) {
+        keys.forEach((key) => queryClient.invalidateQueries({ queryKey: [key] }));
+      }
+    });
+
+    source.addEventListener("error", () => {
+      source.close();
+      source = null;
+      if (!offlineStore.isOffline) {
+        reconnectTimer = setTimeout(() => {
+          reconnectDelay = Math.min(reconnectDelay * 2, 30000);
+          connect();
+        }, reconnectDelay);
+      }
+    });
+  }
+
+  function disconnect() {
+    clearTimeout(reconnectTimer);
+    if (source) {
+      source.close();
+      source = null;
+    }
+  }
+
+  return { connect, disconnect };
+}

--- a/nginx/app.conf
+++ b/nginx/app.conf
@@ -9,6 +9,19 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # SSE endpoint — disable buffering so events reach clients immediately
+    location /api/v2/events/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_redirect off;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+        keepalive_timeout 3600s;
+    }
+
     # Django API
     location /api/ {
         proxy_pass http://127.0.0.1:8000;

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -15,7 +15,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:gunicorn]
-command=gunicorn backend.wsgi:application --bind 127.0.0.1:8000 --workers 3
+command=gunicorn backend.wsgi:application --bind 127.0.0.1:8000 --worker-class gevent --workers 2 --worker-connections 50
 directory=/home/app/web
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary

- New `/api/v2/events/` SSE endpoint using `StreamingHttpResponse` + Redis pub/sub — no ASGI/Channels required
- `notify()` helper called after every write endpoint (chores, areas, areagroups, options, history, vacation toggle) to broadcast invalidation events to all connected clients
- Chore mutations also clear the `areas` Redis cache since area cards embed computed stats (dirtiness, dueCount, totalCount) derived from chore state
- Switched gunicorn to `gevent` worker class so SSE connections don't starve API workers (2 workers × 50 connections each)
- nginx: dedicated `location /api/v2/events/` block with `proxy_buffering off` and 1-hour read timeout
- Frontend `sseComposable`: wraps `EventSource` with exponential backoff reconnect (2s → 30s), pauses when offline, maps event types to `queryClient.invalidateQueries()` calls
- `App.vue`: SSE connects on login/online, disconnects on logout/offline/unmount; wired into existing `isLoggedIn` watcher

## Test plan

- [ ] Open app in two browser tabs (both logged in)
- [ ] Complete a chore in Tab 1 — Tab 2 chore list and area card stats update without refresh
- [ ] Snooze or edit a chore due date in Tab 1 — Tab 2 area dirtiness/dueCount updates
- [ ] Confirm `/api/v2/events/` appears in Network tab as a persistent EventSource connection
- [ ] Confirm keepalive comments (`: keepalive`) arrive every ~25 seconds in the EventStream tab
- [ ] Go offline in Tab 1 — SSE disconnects gracefully; come back online — SSE reconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)