### PR TITLE
feat: bundle redis-server in single-container image for SSE and caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     supervisor \
     netcat-openbsd \
     postgresql-client \
+    redis-server \
     && rm -rf /var/lib/apt/lists/*
 
 # App directory

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -163,23 +163,16 @@ CSRF_TRUSTED_ORIGINS = os.environ.get("CSRF_TRUSTED_ORIGINS").split(" ")
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 USE_X_FORWARDED_HOST = True
 
-if os.environ.get("REDIS_URL"):
-    CACHES = {
-        "default": {
-            "BACKEND": "django_redis.cache.RedisCache",
-            "LOCATION": os.environ.get("REDIS_URL"),
-            "OPTIONS": {
-                "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            },
-            "KEY_PREFIX": "lc",
-        }
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": os.environ.get("REDIS_URL", "redis://localhost:6379/0"),
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
+        "KEY_PREFIX": "lc",
     }
-else:
-    CACHES = {
-        "default": {
-            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
-        }
-    }
+}
 
 CORS_ORIGIN_WHITELIST = os.environ.get("CSRF_TRUSTED_ORIGINS").split(" ")
 

--- a/backend/backend/sse.py
+++ b/backend/backend/sse.py
@@ -6,9 +6,7 @@ from django.http import HttpResponse, StreamingHttpResponse
 
 
 def _get_redis():
-    redis_url = os.environ.get("REDIS_URL")
-    if not redis_url:
-        return None
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
     try:
         import redis
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -14,6 +14,16 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
+[program:redis]
+command=redis-server --daemonize no --bind 127.0.0.1
+autostart=true
+autorestart=true
+priority=15
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
 [program:gunicorn]
 command=gunicorn backend.wsgi:application --bind 127.0.0.1:8000 --worker-class gevent --workers 2 --worker-connections 50
 directory=/home/app/web


### PR DESCRIPTION
## Summary

- Adds `redis-server` to the single-container Docker image so SSE real-time sync and caching work out of the box without an external Redis service
- supervisord starts Redis at priority 15 (before gunicorn, bound to 127.0.0.1)
- `REDIS_URL` now defaults to `redis://localhost:6379/0` in both `sse.py` and `settings.py` — external Redis deployments continue to override via the env var
- Django cache no longer falls back to `DummyCache`; the bundled Redis handles caching in standalone deployments too

## Test plan

- [ ] Build and run the single-container image without setting `REDIS_URL`
- [ ] Confirm `redis-server` is running inside the container (`supervisorctl status`)
- [ ] Confirm SSE sync works between two tabs in the standalone image
- [ ] Confirm deployments with an external Redis (`REDIS_URL` set) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)