### PR TITLE
fix: make area dirtiness progress bar reactive to prop updates

### DIFF
--- a/frontend/src/components/AreaCard.vue
+++ b/frontend/src/components/AreaCard.vue
@@ -185,7 +185,7 @@ const emit = defineEmits(["editArea", "removeArea"]);
 const props = defineProps({
   area: Array,
 });
-const dirtiness = ref(props.area.dirtiness || 0);
+const dirtiness = computed(() => props.area.dirtiness || 0);
 const editForm = ref({
   id: props.area.id || 0,
   area_name: props.area.area_name || "",


### PR DESCRIPTION
## Summary

- `dirtiness` in `AreaCard.vue` was initialized as a `ref(props.area.dirtiness)` — a one-time snapshot that never updated when the parent refetched area data via TanStack Query
- `dueCount` and `totalCount` read directly from `props.area` in the template so they updated correctly; only the progress bar was stale
- Changed to `computed(() => props.area.dirtiness)` so the bar reacts to any prop change, including SSE-driven refetches

## Test plan

- [ ] Edit a chore to set last done in the past and due date of today
- [ ] Confirm the area progress bar resets in the same tab immediately
- [ ] Confirm it also updates in a second tab via SSE without a manual refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)