### PR TITLE
feat: add Docker health checks to all services and containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     netcat-openbsd \
     postgresql-client \
     redis-server \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # App directory
@@ -79,6 +80,9 @@ RUN rm -f /etc/nginx/sites-enabled/default
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost/api/v2/version/list || exit 1
 
 ENTRYPOINT ["/home/app/web/entrypoint.sh"]
 CMD ["/home/app/web/start.app.sh"]

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -5,7 +5,7 @@ FROM python:3.11.4-slim-bookworm AS develop-stage
 WORKDIR /usr/src/app
 
 # install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends gcc
+RUN apt-get update && apt-get install -y --no-install-recommends gcc curl
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -27,6 +27,8 @@ SECRET_KEY = os.environ.get("SECRET_KEY")
 DEBUG = bool(int(os.environ.get("DEBUG")))
 
 ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS").split(" ")
+if DEBUG:
+    ALLOWED_HOSTS += ["localhost", "127.0.0.1"]
 
 
 # Application definition

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -11,8 +11,10 @@ services:
     ports:
       - 7000:80
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     networks:
       - default
     env_file:
@@ -21,6 +23,12 @@ services:
     container_name: lenorechore
     environment:
       - DEBUG=0
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/api/v2/version/list"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
 
   redis:
     image: redis:7-alpine
@@ -28,6 +36,12 @@ services:
       - default
     container_name: lenorechore_redis
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
 
   db:
     image: postgres:15
@@ -43,6 +57,12 @@ services:
       - POSTGRES_USER=${SQL_USER}
       - POSTGRES_PASSWORD=${SQL_PASSWORD}
       - POSTGRES_DB=${SQL_DATABASE}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 30s
+      start_period: 90s
   worker:
     build:
       context: ./backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,12 @@ services:
     environment:
       - NODE_ENV=development
       - TZ=America/New_York
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:5173/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
   backend:
     build:
       context: ./backend
@@ -31,14 +37,22 @@ services:
       - 8001:8001
       - 8002:8002
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     networks:
       - default
     env_file:
       - ./.env.dev
     image: lenorechore_backend:development
     container_name: lenorechore_backend_dev
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8001/api/v2/version/list || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
   worker:
     build:
       context: ./backend
@@ -50,9 +64,12 @@ services:
       - DEBUG=1
       - TZ=America/New_York
     depends_on:
-      - db
-      - backend
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      backend:
+        condition: service_healthy
     networks:
       - default
     env_file:
@@ -65,6 +82,12 @@ services:
       - default
     container_name: lenorechore_redis_dev
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
 
   db:
     image: postgres:15
@@ -80,6 +103,12 @@ services:
       - POSTGRES_PASSWORD=${SQL_PASSWORD}
       - POSTGRES_DB=${SQL_DATABASE}
       - TZ=America/New_York
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary

- **Dockerfile**: added `curl`; `HEALTHCHECK` polls `/api/v2/version/list` (no auth required) every 30s with a 60s start period to allow migrations and fixture loading to complete before checks begin
- **backend/Dockerfile.dev**: added `curl` so the dev backend container can run its healthcheck
- **docker-compose.yml**: healthchecks for all four services; `depends_on` upgraded from simple list to `condition: service_healthy` — backend and worker now wait for db and redis to be confirmed healthy before starting
- **docker-compose-prod.yml**: same treatment for app, redis, and db

## Health check summary

| Service | Test | Start period |
|---|---|---|
| app / backend | `curl -f http://localhost/api/v2/version/list` | 60s |
| redis | `redis-cli ping` | 5s |
| db | `pg_isready -U $POSTGRES_USER -d $POSTGRES_DB` | 15s |
| frontend (dev) | `wget -q --spider http://localhost:5173/` | 30s |

## Test plan

- [ ] `docker compose up` — confirm all containers reach `healthy` status (`docker compose ps`)
- [ ] Kill the Redis container — confirm dependent services are marked `unhealthy`
- [ ] Prod single-container image: `docker inspect lenorechore | grep -A5 Health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)