### PR TITLE
fix: always include localhost in ALLOWED_HOSTS for health checks

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -26,9 +26,7 @@ SECRET_KEY = os.environ.get("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = bool(int(os.environ.get("DEBUG")))
 
-ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS").split(" ")
-if DEBUG:
-    ALLOWED_HOSTS += ["localhost", "127.0.0.1"]
+ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS").split(" ") + ["localhost", "127.0.0.1"]
 
 
 # Application definition


### PR DESCRIPTION
## Summary

The Dockerfile `HEALTHCHECK` runs `curl -f http://localhost/api/v2/version/list` which hits nginx with `Host: localhost`. Nginx proxies it to gunicorn preserving the host header, and Django rejects it with 400 DisallowedHost when `localhost` is not in `ALLOWED_HOSTS`.

The previous fix only added `localhost` when `DEBUG=True`, which didn't cover the production single-container image (`DEBUG=False`).

`localhost` and `127.0.0.1` are now always appended unconditionally. This is safe — no external traffic reaches Django via `localhost`; only internal health check probes do.

## Test plan

- [ ] Rebuild and run the single-container prod image — container should reach `(healthy)` status
- [ ] `docker inspect lenorechore | grep -A5 '"Health"'` shows passing checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)