### PR TITLE
fix: revert theme.change() to theme.global.name.value (prod white screen)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -156,16 +156,20 @@ const checkSession = async () => {
 };
 
 // ── Theme ───────────────────────────────────────────────────────────────────
-vuetifyTheme.change(
-  themeStore.isDark ? "myCustomDarkTheme" : "myCustomLightTheme"
-);
+// NOTE: use theme.global.name.value (not theme.change()). theme.change() does
+// not exist in the vuetify version pinned in package-lock (3.6.8) and crashes
+// the app at setup in production builds; the deprecation warning only appears
+// on newer 3.x. This form works across all 3.x versions.
+vuetifyTheme.global.name.value = themeStore.isDark
+  ? "myCustomDarkTheme"
+  : "myCustomLightTheme";
 
 watch(
   () => themeStore.isDark,
   (isDark) => {
-    vuetifyTheme.change(
-      isDark ? "myCustomDarkTheme" : "myCustomLightTheme"
-    );
+    vuetifyTheme.global.name.value = isDark
+      ? "myCustomDarkTheme"
+      : "myCustomLightTheme";
   }
 );
 


### PR DESCRIPTION
## Summary

The package-update PR (#63) replaced the deprecated `theme.global.name.value = X` with `theme.change(X)`, based on a Vuetify deprecation warning seen in dev. But that warning came from Vuetify **3.12.7** (what the dev container resolved), while `package-lock.json` pins Vuetify **3.6.8** — the version built into the production single-container image. `theme.change()` does not exist in 3.6.8.

Result: a fresh production load threw `TypeError: r.change is not a function` at App `setup()`, crashing before mount → **white screen**. It never surfaced in dev because (a) dev runs 3.12.7 which has the method, and (b) the failing call is a top-level setup statement that HMR didn't re-execute during testing.

### Fix
Revert both the initial theme set and the dark-mode watcher to `theme.global.name.value = X`. This is the exact form that shipped in prod before the upgrade and works across all Vuetify 3.x versions (deprecated only on newer 3.x, fully functional).

### Note on the version skew
Verified the rest of the lockfile is consistent with the intended updates (vue 3.5.35, axios 1.16.1, @tanstack/vue-query 5.100.14, chart.js 4.5.1, vite 7.3.5 all match package.json). Vuetify is the only outlier because its range was deliberately left at `^3.6.8`, so the lock correctly stays at 3.6.8. No other code assumed the newer Vuetify API.

## Test plan

- [x] Frontend tests pass (7/7)
- [ ] CI green
- [ ] Rebuild sandbox single-container image → app displays, theme toggle works, no console crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)