### PR TITLE
feat: skip bundled Redis when an external REDIS_URL is configured

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ COPY backend/ $APP_HOME/
 # Scripts
 RUN sed -i 's/\r$//g' $APP_HOME/entrypoint.sh && chmod +x $APP_HOME/entrypoint.sh
 RUN sed -i 's/\r$//g' $APP_HOME/start.app.sh && chmod +x $APP_HOME/start.app.sh
+RUN sed -i 's/\r$//g' $APP_HOME/start-redis.sh && chmod +x $APP_HOME/start-redis.sh
 
 # Nginx config
 COPY nginx/app.conf /etc/nginx/conf.d/default.conf

--- a/backend/start-redis.sh
+++ b/backend/start-redis.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Conditionally start the Redis bundled in the single-container image.
+#
+# The app defaults REDIS_URL to redis://localhost:6379/0 (the bundled
+# instance). When the operator points REDIS_URL at their own Redis server,
+# the bundled instance is redundant, so we skip starting it. Exiting 0 here
+# (with autorestart=unexpected in supervisord) marks this program EXITED
+# without triggering a restart loop, so no idle process lingers.
+
+case "${REDIS_URL:-}" in
+  "" | redis://localhost:* | redis://127.0.0.1:* | rediss://localhost:* | rediss://127.0.0.1:*)
+    echo "No external REDIS_URL configured; starting bundled Redis."
+    exec redis-server --daemonize no --bind 127.0.0.1
+    ;;
+  *)
+    echo "External REDIS_URL configured; bundled Redis not started."
+    exit 0
+    ;;
+esac

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -15,9 +15,11 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:redis]
-command=redis-server --daemonize no --bind 127.0.0.1
+command=/home/app/web/start-redis.sh
 autostart=true
-autorestart=true
+autorestart=unexpected
+exitcodes=0
+startsecs=0
 priority=15
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
## Summary

The single-container image started its bundled `redis-server` unconditionally via supervisord, even when the operator supplied their own Redis through `REDIS_URL`. That left a redundant Redis process running (and emitting the `vm.overcommit_memory` startup warning) for no reason.

The redis supervisord program now runs **`start-redis.sh`**, which:
- Starts the bundled Redis when `REDIS_URL` is **unset** or points at **localhost / 127.0.0.1** (the default, self-contained deployment)
- **Exits 0** for any external host, so the bundled instance never launches

Supervisord config changed to `autorestart=unexpected` + `exitcodes=0` + `startsecs=0`, so the clean exit marks the program `EXITED` (no restart loop, no lingering process) while a real Redis crash (non-zero exit) still restarts.

### Case-matching verified
| `REDIS_URL` | Result |
|---|---|
| _unset_ | bundled |
| `redis://localhost:6379/0` | bundled |
| `redis://127.0.0.1:6379/0` | bundled |
| `rediss://localhost:6380/0` | bundled |
| `redis://my-redis.example.com:6379/0` | skip |
| `redis://:secret@redis.internal:6379/0` | skip |

### Scope
Single-container (prod) image only. Dev is unaffected — it uses a separate `redis` service in `docker-compose.yml`, not supervisord. No Python/JS changes, so the test suites are unaffected.

## Test plan

- [ ] CI green
- [ ] Sandbox default (no external REDIS_URL): bundled Redis starts, app works, SSE syncs
- [ ] Sandbox with external `REDIS_URL`: bundled Redis does **not** start (supervisord shows redis EXITED), app uses external Redis, SSE syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)