### PR TITLE
docs: document REDIS_URL and bundled vs external Redis behavior

### DIFF
--- a/backend/docs/index.md
+++ b/backend/docs/index.md
@@ -100,9 +100,12 @@ Make sure you have the following installed on your system:
 <!-- INSTALLATION -->
 ### Step 1: Create a `.env` File
 
-Create a `.env` file in the root directory of the project. PostgreSQL and Redis are both **optional** — if omitted, LenoreChore will use SQLite and an in-memory cache automatically.
+Create a `.env` file in the root directory of the project.
 
-**Minimal setup** (SQLite + in-memory cache):
+- **PostgreSQL is optional** — if the `SQL_*` variables are omitted, LenoreChore falls back to SQLite automatically.
+- **Redis is bundled** into the container and used automatically for caching and real-time sync — no configuration required. To use your own Redis server instead, set `REDIS_URL` (see [Using an external Redis](#using-an-external-redis)); the bundled instance is then skipped.
+
+**Minimal setup** (SQLite + bundled Redis):
 
 ```env
 DEBUG=0
@@ -115,7 +118,7 @@ DJANGO_SUPERUSER_USERNAME=supervisor
 TIMEZONE=America/New_York
 ```
 
-**Full setup** (PostgreSQL + Redis):
+**Full setup** (PostgreSQL + external Redis):
 
 ```env
 DEBUG=0
@@ -136,6 +139,26 @@ REDIS_URL=redis://redis:6379/0
 ```
 
 Adjust these values according to your environment and application requirements.
+
+#### Using an external Redis
+
+`REDIS_URL` is **optional**. When it is unset (or points at `localhost` /
+`127.0.0.1`), LenoreChore uses the Redis bundled inside the container. To use
+your own Redis server instead, set `REDIS_URL` to point at it — the bundled
+instance is then skipped automatically, so no redundant Redis runs.
+
+Format: `redis://[:password@]host:port/db`
+
+| Scenario | `REDIS_URL` |
+|---|---|
+| Bundled Redis (default) | _unset_ |
+| Redis running as a Compose service named `redis` | `redis://redis:6379/0` |
+| External host by address | `redis://10.1.10.50:6379/0` |
+| Password-protected | `redis://:yourpassword@redis.internal:6379/0` |
+| TLS | `rediss://redis.internal:6380/0` |
+
+Redis is used only for ephemeral caching and SSE pub/sub, so no persistence is
+required on the external server.
 
 ### Step 2: Create a `docker-compose.yml` File
 

--- a/example.env
+++ b/example.env
@@ -14,3 +14,6 @@ DJANGO_SUPERUSER_EMAIL=someone@somewhere.com
 DJANGO_SUPERUSER_USERNAME=supervisor
 VITE_API_KEY=someapikey
 TIMEZONE=America/New_York
+# Optional: use your own Redis server. If unset, the bundled Redis is used and
+# the external instance below is ignored. Format: redis://[:password@]host:port/db
+# REDIS_URL=redis://redis:6379/0


### PR DESCRIPTION
## Summary

The installation docs predated bundling Redis into the single-container image and still said Redis was optional with an "in-memory cache" fallback — no longer accurate. Updated to reflect how it actually works now, and to document the external-Redis option enabled by #66.

### Changes
- **`backend/docs/index.md`**:
  - Clarified PostgreSQL is optional (SQLite fallback) and Redis is **bundled** and used automatically
  - New **"Using an external Redis"** section explaining `REDIS_URL` is optional, what the bundled-vs-external behavior is (bundled instance skipped when `REDIS_URL` points externally), the URL format, and a table of examples (Compose service, external host, password, TLS)
  - Relabeled the "minimal" setup as SQLite + bundled Redis
- **`example.env`**: added `REDIS_URL` as an optional commented line with format hint

### Verification
- `mkdocs build` succeeds; no link/anchor warnings introduced (the 3 strict-mode warnings are pre-existing griffe docstring issues unrelated to this change)

## Test plan

- [ ] CI green
- [ ] Docs render correctly (the "Using an external Redis" anchor link resolves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)