### PR TITLE
feat: version/details endpoint + About page

### DIFF
--- a/backend/api/tests/api/test_sse_api.py
+++ b/backend/api/tests/api/test_sse_api.py
@@ -15,3 +15,26 @@ def test_version_endpoint_no_auth_required(api_client, version):
     response = api_client.get("/api/v2/version/list")
     assert response.status_code == 200
     assert response.json()["version_number"] == version.version_number
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_version_details_requires_auth(api_client):
+    """The detailed version endpoint must NOT be public."""
+    response = api_client.get("/api/v2/version/details")
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_version_details_reports_stack(auth_client, version):
+    response = auth_client.get("/api/v2/version/details")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["app_version"] == version.version_number
+    assert data["python_version"]
+    assert data["django_version"]
+    # packages is a name->version map including known dependencies
+    assert isinstance(data["packages"], dict)
+    assert "django-ninja" in data["packages"]
+    assert data["packages"]["django-ninja"] != "not installed"

--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -11,7 +11,7 @@ from api.models import (
     Option,
     Version,
 )
-from typing import List, Optional
+from typing import Dict, List, Optional
 from django.shortcuts import get_object_or_404
 from datetime import date, timedelta
 from ninja.errors import HttpError
@@ -20,6 +20,9 @@ from django.db.models import Count
 from django.utils import timezone
 from django.core.paginator import Paginator
 from django.core.cache import cache
+import importlib.metadata
+import platform
+import django
 
 CACHE_TTL = 15 * 60  # 15 minutes
 
@@ -60,6 +63,24 @@ class VersionOut(Schema):
 
     id: int
     version_number: str
+
+
+class VersionDetailsOut(Schema):
+    """
+    Schema reporting the app version alongside key runtime/dependency
+    versions, for confirming what a deployment is actually running.
+
+    Attributes:
+        app_version (str): The LenoreChore release version.
+        python_version (str): The running Python version.
+        django_version (str): The installed Django version.
+        packages (Dict[str, str]): Map of key package name to installed version.
+    """
+
+    app_version: str
+    python_version: str
+    django_version: str
+    packages: Dict[str, str]
 
 
 class LoginUserSchema(Schema):
@@ -1493,6 +1514,60 @@ def list_version(request):
         return qs
     except Exception as e:
         raise HttpError(500, f"Record retrieval error: {str(e)}")
+
+
+# Packages reported by /version/details. Add or remove names here as needed.
+VERSION_DETAIL_PACKAGES = [
+    "django-ninja",
+    "djangorestframework",
+    "django-redis",
+    "django-q2",
+    "django-allauth",
+    "django-filter",
+    "gunicorn",
+    "gevent",
+    "pillow",
+    "arrow",
+    "setuptools",
+    "wheel",
+]
+
+
+@api.get("/version/details", response=VersionDetailsOut)
+def version_details(request):
+    """
+    The function `version_details` reports the app version alongside the
+    running Python/Django versions and a set of key installed package
+    versions, so a deployment's full stack can be confirmed from one call.
+
+    Authentication is required, so exact dependency versions are not exposed
+    publicly. The unauthenticated `/version/list` endpoint (used by the UI
+    update check) is unchanged.
+
+    Endpoint:
+        - **Path**: `/api/v2/version/details`
+        - **Method**: `GET`
+
+    Args:
+        request (HttpRequest): The HTTP request object.
+
+    Returns:
+        (VersionDetailsOut): App, Python, Django, and package versions.
+    """
+    packages = {}
+    for name in VERSION_DETAIL_PACKAGES:
+        try:
+            packages[name] = importlib.metadata.version(name)
+        except importlib.metadata.PackageNotFoundError:
+            packages[name] = "not installed"
+
+    version_obj = Version.objects.filter(id=1).first()
+    return VersionDetailsOut(
+        app_version=version_obj.version_number if version_obj else "unknown",
+        python_version=platform.python_version(),
+        django_version=django.get_version(),
+        packages=packages,
+    )
 
 
 api.add_router("/auth", router)

--- a/frontend/src/composables/versionComposable.js
+++ b/frontend/src/composables/versionComposable.js
@@ -27,6 +27,28 @@ async function getVersionFunction() {
   }
 }
 
+async function getVersionDetailsFunction() {
+  try {
+    const response = await apiClient.get("/version/details");
+    return response.data;
+  } catch (error) {
+    handleApiError(error, "Version details not fetched: ");
+  }
+}
+
+export function useVersionDetails() {
+  const { data: versionDetails, isLoading } = useQuery({
+    queryKey: ["versionDetails"],
+    queryFn: () => getVersionDetailsFunction(),
+    select: response => response,
+  });
+
+  return {
+    isLoading,
+    versionDetails,
+  };
+}
+
 export function useVersion() {
   const queryClient = useQueryClient();
   const { data: version, isLoading } = useQuery({

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -7,6 +7,7 @@ import ProfileView from "../views/ProfileView.vue";
 import SettingsView from "../views/SettingsView.vue";
 import LogoutView from "../views/LogoutView.vue";
 import LoginView from "../views/LoginView.vue";
+import AboutView from "../views/AboutView.vue";
 import FourView from "../views/FourView.vue";
 import { useUserStore } from "@/stores/user";
 
@@ -51,6 +52,12 @@ const routes = [
     path: "/logout",
     name: "logout",
     component: LogoutView,
+    meta: { requiresAuth: true },
+  },
+  {
+    path: "/about",
+    name: "about",
+    component: AboutView,
     meta: { requiresAuth: true },
   },
   {

--- a/frontend/src/views/AboutView.vue
+++ b/frontend/src/views/AboutView.vue
@@ -1,0 +1,102 @@
+<template>
+  <v-container class="pa-4 mx-auto" style="max-width: 700px">
+    <v-card :rounded="$vuetify.display.smAndDown ? 0 : undefined">
+      <v-card-item>
+        <v-img src="logov2.png" max-width="200" class="mb-2"></v-img>
+        <v-card-title>About LenoreChore</v-card-title>
+        <v-card-subtitle>A simple chore app</v-card-subtitle>
+      </v-card-item>
+
+      <v-divider></v-divider>
+
+      <v-card-text>
+        <v-list density="compact" class="bg-transparent">
+          <v-list-item title="Frontend version">
+            <template v-slot:append>
+              <span class="text-medium-emphasis">{{ appVersion }}</span>
+            </template>
+          </v-list-item>
+          <v-list-item title="Backend version">
+            <template v-slot:append>
+              <span class="text-medium-emphasis">{{
+                versionDetails?.app_version ?? "—"
+              }}</span>
+            </template>
+          </v-list-item>
+          <v-list-item title="Python">
+            <template v-slot:append>
+              <span class="text-medium-emphasis">{{
+                versionDetails?.python_version ?? "—"
+              }}</span>
+            </template>
+          </v-list-item>
+          <v-list-item title="Django">
+            <template v-slot:append>
+              <span class="text-medium-emphasis">{{
+                versionDetails?.django_version ?? "—"
+              }}</span>
+            </template>
+          </v-list-item>
+        </v-list>
+
+        <div
+          v-if="
+            !isLoading && appVersion !== versionDetails?.app_version &&
+            versionDetails?.app_version
+          "
+          class="text-warning text-caption px-4 pb-2"
+        >
+          <v-icon icon="mdi-alert" size="small"></v-icon>
+          Frontend and backend versions differ.
+        </div>
+
+        <v-divider class="my-2"></v-divider>
+
+        <div class="text-subtitle-2 px-4 pb-1">Backend packages</div>
+        <div v-if="isLoading" class="text-center py-4">
+          <v-progress-circular
+            indeterminate
+            color="primary"
+            size="28"
+          ></v-progress-circular>
+        </div>
+        <v-table v-else-if="versionDetails" density="compact">
+          <tbody>
+            <tr v-for="(ver, name) in versionDetails.packages" :key="name">
+              <td>{{ name }}</td>
+              <td class="text-right text-medium-emphasis">{{ ver }}</td>
+            </tr>
+          </tbody>
+        </v-table>
+        <div v-else class="text-medium-emphasis px-4 py-2">
+          Version details unavailable.
+        </div>
+      </v-card-text>
+
+      <v-divider></v-divider>
+
+      <v-card-actions>
+        <v-btn
+          href="https://github.com/Novanglus96/LenoreChore"
+          target="_blank"
+          rel="noopener"
+          prepend-icon="mdi-github"
+          variant="text"
+        >
+          GitHub
+        </v-btn>
+        <v-spacer></v-spacer>
+        <v-btn to="/" variant="text">Back</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-container>
+</template>
+
+<script setup>
+import { useVersionDetails } from "@/composables/versionComposable";
+import { version as appVersion } from "../../package.json";
+
+const { versionDetails, isLoading } = useVersionDetails();
+</script>
+
+<style scoped></style>

--- a/frontend/src/views/AppNavigation.vue
+++ b/frontend/src/views/AppNavigation.vue
@@ -25,7 +25,10 @@
       </v-list>
       <v-divider></v-divider>
       <v-list>
-        <v-list-item to="/about" title="About LenoreChore">
+        <v-list-item to="/about">
+          <v-list-item-title class="text-body-2 font-italic text-secondary text-center">
+            About LenoreChore
+          </v-list-item-title>
           <v-list-item-title class="text-body-2 font-italic text-secondary text-center">
             version {{ appVersion }}
           </v-list-item-title>

--- a/frontend/src/views/AppNavigation.vue
+++ b/frontend/src/views/AppNavigation.vue
@@ -25,7 +25,7 @@
       </v-list>
       <v-divider></v-divider>
       <v-list>
-        <v-list-item to="/about" title="View app and stack versions">
+        <v-list-item to="/about" title="About LenoreChore">
           <v-list-item-title class="text-body-2 font-italic text-secondary text-center">
             version {{ appVersion }}
           </v-list-item-title>

--- a/frontend/src/views/AppNavigation.vue
+++ b/frontend/src/views/AppNavigation.vue
@@ -25,7 +25,7 @@
       </v-list>
       <v-divider></v-divider>
       <v-list>
-        <v-list-item>
+        <v-list-item to="/about" title="View app and stack versions">
           <v-list-item-title class="text-body-2 font-italic text-secondary text-center">
             version {{ appVersion }}
           </v-list-item-title>

--- a/frontend/src/views/AppNavigation.vue
+++ b/frontend/src/views/AppNavigation.vue
@@ -30,7 +30,7 @@
             About LenoreChore
           </v-list-item-title>
           <v-list-item-title class="text-body-2 font-italic text-secondary text-center">
-            version {{ appVersion }}
+            {{ appVersion }}
           </v-list-item-title>
         </v-list-item>
       </v-list>

--- a/frontend/src/views/AppNavigation.vue
+++ b/frontend/src/views/AppNavigation.vue
@@ -29,7 +29,7 @@
           <v-list-item-title class="text-body-2 font-italic text-secondary text-center">
             About LenoreChore
           </v-list-item-title>
-          <v-list-item-title class="text-body-2 font-italic text-secondary text-center">
+          <v-list-item-title class="text-caption font-italic text-medium-emphasis text-center">
             {{ appVersion }}
           </v-list-item-title>
         </v-list-item>


### PR DESCRIPTION
## Summary

Adds a one-call way to confirm exactly what a deployment is running, surfaced both as an API and an in-app **About page**.

### Backend — `GET /api/v2/version/details`
Reports app version, Python, Django, and key installed package versions (read live via `importlib.metadata`, so it reflects what's actually in the container):
```json
{
  "app_version": "1.4.0-alpha.x",
  "python_version": "3.11.4",
  "django_version": "5.2.14",
  "packages": { "django-ninja": "1.6.2", "setuptools": "78.1.1", "wheel": "0.46.2", "...": "..." }
}
```
- **Requires authentication** — avoids public version fingerprinting.
- The existing unauthenticated **`/version/list`** (used by the UI update banner) is **untouched**.

### Frontend — About page
- New `/about` view (auth-gated) showing frontend version, backend version, Python, Django, and a table of backend package versions.
- Reached by **clicking the "version x.y.z" line** at the bottom of the nav menu.
- Warns if frontend and backend app versions differ (deploy mismatch diagnostic).
- `useVersionDetails()` composable; loading + unavailable states handled.

## Test plan

- [x] `ruff` clean; backend suite **32 passed** (2 new: auth gate + payload shape)
- [x] Live: unauthenticated `/version/details` returns 401
- [x] Frontend: ESLint clean, 7/7 vitest, dev HMR + production build compile the About view
- [ ] CI green
- [ ] Sandbox: log in, click the version in the menu, confirm the About page shows the stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)