### PR TITLE
docs: clear griffe return-annotation warnings (strict docs build passes)

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -96,7 +96,7 @@ class CustomUser(AbstractUser):
         return self.email
 
     @property
-    def fullname(self):
+    def fullname(self) -> str:
         """
         Returns the user's full name as a single string.
 
@@ -340,7 +340,7 @@ class Option(SingletonModel):
         return "Options"
 
     @classmethod
-    def load(cls):
+    def load(cls) -> "Option":
         """
         Load the singleton Option instance.
 

--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -1560,7 +1560,7 @@ def delete_historyitem(request, historyitem_id: int):
 
 
 @api.get("/version/list", response=VersionOut, auth=None)
-def list_version(request):
+def list_version(request) -> VersionOut:
     """
     The function `list_version` retrieves the app version number
     from the backend.


### PR DESCRIPTION
## Summary

The dev container's mkdocs logs showed griffe WARNINGs on every build (and `mkdocs build --strict` aborted) because three methods documented a return type in their docstring but had no return annotation:

- `CustomUser.fullname` → `-> str`
- `Option.load` → `-> "Option"`
- `list_version` → `-> VersionOut` (django-ninja still uses the `response=` kwarg for serialization; the annotation is documentation-only and doesn't change behavior)

These are pre-existing and unrelated to any feature — the push-notification fields just shifted the line numbers, which is what surfaced them.

## Test plan

- [x] `ruff` clean
- [x] Full backend suite: **45 passed** (includes the `/version/list` test, confirming the ninja annotation change is harmless)
- [x] `mkdocs build --strict` now passes with **zero warnings** (previously aborted)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)