### PR TITLE
fix: make daily reminders reachable and usable (Profile link + layout + time picker)

### DIFF
--- a/frontend/src/views/AppNavigation.vue
+++ b/frontend/src/views/AppNavigation.vue
@@ -98,6 +98,9 @@
           v-model="showVacationForm"
           @update-dialog="updateVacationDialog"
         />
+        <v-list-item to="/profile" prepend-icon="mdi-account">
+          <v-list-item-title>Profile</v-list-item-title>
+        </v-list-item>
         <v-list-item to="/logout" prepend-icon="mdi-logout">
           <v-list-item-title>Logout</v-list-item-title>
         </v-list-item>


### PR DESCRIPTION
## Summary

Three fixes so the daily reminders feature (from #72) is actually accessible and usable.

1. **Profile was unreachable** — the `/profile` route existed but had no link anywhere in the UI. Added a **Profile** entry (`mdi-account`) to the top-right ⋮ overflow menu, above Logout.
2. **Reminders section was below the Save button** — it read like an orphaned afterthought. Moved it above the Change Password / Save Changes actions, grouped with the other profile settings.
3. **Time picker dropdown was clipped** — on desktop it rendered below/outside the profile card and was unusable. Added `teleport` so the dropdown floats over the page.

## Test plan

- [ ] ⋮ menu → **Profile** opens the Profile page
- [ ] "Daily reminders" appears above the Save Changes button
- [ ] Toggle on → the time picker opens a usable dropdown (not clipped by the card)

> Note: the toggle only renders when the browser supports push in a secure context (HTTPS or `localhost`); over plain HTTP it shows a "not supported" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)