### PR TITLE
fix: reposition daily reminders above Save and teleport the time picker

### DIFF
--- a/frontend/src/components/ProfileForm.vue
+++ b/frontend/src/components/ProfileForm.vue
@@ -74,47 +74,48 @@
             </v-col>
           </v-row>
         </v-container>
+        <v-divider class="mb-3"></v-divider>
+        <v-container>
+          <template v-if="pushSupported">
+            <v-row align="center" no-gutters>
+              <v-col>
+                <div class="text-subtitle-2">Daily reminders</div>
+                <div class="text-caption text-medium-emphasis">
+                  A daily summary of what's due and overdue.
+                </div>
+              </v-col>
+              <v-col cols="auto">
+                <v-switch
+                  v-model="notifyEnabled"
+                  color="white"
+                  hide-details
+                  :loading="notifyBusy"
+                  @update:modelValue="onToggleReminders"
+                ></v-switch>
+              </v-col>
+            </v-row>
+            <v-row v-if="notifyEnabled" no-gutters align="center" class="mt-2">
+              <v-col cols="auto" class="me-3 text-body-2">Remind me at</v-col>
+              <v-col cols="auto" style="min-width: 150px">
+                <VueDatePicker
+                  v-model="notifyTime"
+                  time-picker
+                  auto-apply
+                  :teleport="true"
+                  @update:modelValue="onTimeChange"
+                ></VueDatePicker>
+              </v-col>
+            </v-row>
+          </template>
+          <div v-else class="text-caption text-medium-emphasis">
+            Daily reminders aren't supported on this device or browser.
+          </div>
+        </v-container>
         <v-card-actions>
           <v-btn variant="outlined">Change Password</v-btn>
           <v-btn variant="outlined" type="submit">Save Changes</v-btn>
         </v-card-actions>
       </Form>
-    </v-card-text>
-    <v-divider></v-divider>
-    <v-card-text>
-      <template v-if="pushSupported">
-        <v-row align="center" no-gutters>
-          <v-col>
-            <div class="text-subtitle-2">Daily reminders</div>
-            <div class="text-caption text-medium-emphasis">
-              A daily summary of what's due and overdue.
-            </div>
-          </v-col>
-          <v-col cols="auto">
-            <v-switch
-              v-model="notifyEnabled"
-              color="white"
-              hide-details
-              :loading="notifyBusy"
-              @update:modelValue="onToggleReminders"
-            ></v-switch>
-          </v-col>
-        </v-row>
-        <v-row v-if="notifyEnabled" no-gutters align="center" class="mt-2">
-          <v-col cols="auto" class="me-3 text-body-2">Remind me at</v-col>
-          <v-col cols="auto" style="min-width: 150px">
-            <VueDatePicker
-              v-model="notifyTime"
-              time-picker
-              auto-apply
-              @update:modelValue="onTimeChange"
-            ></VueDatePicker>
-          </v-col>
-        </v-row>
-      </template>
-      <div v-else class="text-caption text-medium-emphasis">
-        Daily reminders aren't supported on this device or browser.
-      </div>
     </v-card-text>
     <v-snackbar
       v-model="snackbar"


### PR DESCRIPTION
## Summary

Follow-up to #73 — these two ProfileForm fixes were committed after #73 had already merged, so they need their own PR.

1. **Reminders section was below the Save button** — it read like an orphaned afterthought. Moved it above the Change Password / Save Changes actions, grouped with the other profile settings.
2. **Time picker dropdown was clipped** — on desktop it rendered below/outside the profile card and was unusable. Added `teleport` so the dropdown floats over the page.

## Test plan

- [ ] Profile → "Daily reminders" appears above the Save Changes button
- [ ] Toggle on → the time picker opens a usable dropdown (not clipped by the card)

🤖 Generated with [Claude Code](https://claude.com/claude-code)