### PR TITLE
fix: profile name fields — pre-fill values and move labels above inputs

### DIFF
--- a/frontend/src/components/ProfileForm.vue
+++ b/frontend/src/components/ProfileForm.vue
@@ -14,7 +14,15 @@
       >{{ formData.first_name }} {{ formData.last_name }}</v-card-subtitle
     >
     <v-card-text class="py-0">
-      <Form @submit="submitForm" :validation-schema="schema" v-slot="{ errors }">
+      <Form
+        @submit="submitForm"
+        :validation-schema="schema"
+        :initial-values="{
+          first_name: formData.first_name,
+          last_name: formData.last_name,
+        }"
+        v-slot="{ errors }"
+      >
         <v-container>
           <v-row>
             <v-col>

--- a/frontend/src/components/ProfileForm.vue
+++ b/frontend/src/components/ProfileForm.vue
@@ -27,20 +27,20 @@
           <v-row>
             <v-col>
               <Field name="first_name" v-slot="{ field }">
+                <div class="text-body-2 mb-1">First name</div>
                 <v-text-field
                   v-bind="field"
                   :counter="20"
-                  label="First name"
                   :error-messages="errors.first_name"
                 ></v-text-field>
               </Field>
             </v-col>
             <v-col>
               <Field name="last_name" v-slot="{ field }">
+                <div class="text-body-2 mb-1">Last name</div>
                 <v-text-field
                   v-bind="field"
                   :counter="20"
-                  label="Last name"
                   :error-messages="errors.last_name"
                 ></v-text-field>
               </Field>


### PR DESCRIPTION
## Summary

Two fixes to the First name / Last name fields on the Profile page.

1. **Empty inputs** — the fields are vee-validate `<Field>`s but the `<Form>` had no `:initial-values`, so they rendered empty even though the store held the names (the card subtitle showed them fine). Added `:initial-values` so they pre-fill.
2. **Overlapping labels** — Vuetify's floating in-field label sat on top of the value and was hard to read. Moved "First name"/"Last name" to plain labels above each input.

## Test plan

- [ ] Profile → First name and Last name are pre-filled with your name
- [ ] Labels sit above the inputs and don't overlap the text
- [ ] Edit a name + Save Changes → persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)