### PR TITLE
fix: scheduletasks crash left the daily-notification schedule uncreated

### DIFF
--- a/backend/api/management/commands/scheduletasks.py
+++ b/backend/api/management/commands/scheduletasks.py
@@ -58,22 +58,19 @@ class Command(BaseCommand):
         for task in tasks:
             next_run = ""
             schedule_type = ""
-            if task["start_today"]:
-                next_run = datetime.combine(
-                    today, datetime.strptime(task["time"], "%H:%M").time()
-                )
-            else:
-                next_run = datetime.combine(
-                    tomorrow, datetime.strptime(task["time"], "%H:%M").time()
-                )
-            next_run = next_run.astimezone(current_timezone)
-            if task["type"] == "DAILY":
-                schedule_type = Schedule.DAILY
-            elif task["type"] == "HOURLY":
-                schedule_type = Schedule.HOURLY
-            elif task["type"] == "MINUTES":
+            if task["type"] == "MINUTES":
+                # Interval schedules run immediately; they have no clock time.
                 schedule_type = Schedule.MINUTES
                 next_run = timezone.now()
+            else:
+                day = today if task["start_today"] else tomorrow
+                next_run = datetime.combine(
+                    day, datetime.strptime(task["time"], "%H:%M").time()
+                ).astimezone(current_timezone)
+                if task["type"] == "DAILY":
+                    schedule_type = Schedule.DAILY
+                elif task["type"] == "HOURLY":
+                    schedule_type = Schedule.HOURLY
             existing_schedule = Schedule.objects.filter(
                 name=task["task_name"]
             ).first()

--- a/backend/api/tests/unit/test_scheduletasks.py
+++ b/backend/api/tests/unit/test_scheduletasks.py
@@ -1,0 +1,36 @@
+import pytest
+from django.core.management import call_command
+
+
+@pytest.mark.django_db
+@pytest.mark.unit
+def test_scheduletasks_creates_both_schedules():
+    """The command must register both the daily and the interval schedule.
+
+    Regression guard: an empty time on the MINUTES task previously crashed
+    the command, so "Send Due Notifications" was never created.
+    """
+    from django_q.models import Schedule
+
+    call_command("scheduletasks")
+
+    names = set(Schedule.objects.values_list("name", flat=True))
+    assert "Process Seasonal Chores" in names
+    assert "Send Due Notifications" in names
+
+    notif = Schedule.objects.get(name="Send Due Notifications")
+    assert notif.schedule_type == Schedule.MINUTES
+    assert notif.minutes == 5
+    assert notif.func == "api.tasks.send_due_notifications"
+
+
+@pytest.mark.django_db
+@pytest.mark.unit
+def test_scheduletasks_is_idempotent():
+    from django_q.models import Schedule
+
+    call_command("scheduletasks")
+    call_command("scheduletasks")
+
+    assert Schedule.objects.filter(name="Send Due Notifications").count() == 1
+    assert Schedule.objects.filter(name="Process Seasonal Chores").count() == 1


### PR DESCRIPTION
## Summary

Daily reminders never fired automatically because the **schedule was never created**. The `scheduletasks` command crashed while registering the interval task:

```
ValueError: time data '' does not match format '%H:%M'
```

The "Send Due Notifications" task is a `MINUTES` (interval) schedule with no clock time (`time: ""`), but the command parsed `task["time"]` with `strptime` in the `start_today` block **before** reaching the `MINUTES` branch. The empty string raised `ValueError`, the command aborted partway through the loop, and the django-q `Schedule` row was never created. The notification *function* worked fine when called directly — only the scheduling was broken, which is exactly the "manual run works, automatic never fires" symptom.

### Fix
Handle `MINUTES` first (interval schedules run immediately and have no clock time), and only parse `task["time"]` for `DAILY`/`HOURLY`. Verified: after the fix, both `Send Due Notifications` (type `I`, every 5 min) and `Process Seasonal Chores` (type `D`) are registered.

### Tests
Added `test_scheduletasks.py` — runs the command and asserts both schedules exist (the MINUTES one with `minutes=5`), plus idempotency. This would have caught the crash. Full suite: **50 passed**.

> Deploy note: existing deployments that hit the crash have only the seasonal schedule. On the next container start (or `manage.py scheduletasks`) with this fix, the notification schedule is created.

## Test plan

- [x] `scheduletasks` runs clean; both schedules present
- [x] 50 backend tests pass
- [ ] CI green
- [ ] Sandbox: rebuild, confirm `Send Due Notifications` appears in django-q schedules and a reminder fires automatically at the set time (reset `last_notified_date` if already marked today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)