### PR TITLE
feat: suppress daily reminders while vacation mode is active

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -6,7 +6,7 @@ Author: John Adams <johnmadams96@gmail.com>
 Date: February 15, 2024
 """
 
-from api.models import Chore, CustomUser
+from api.models import Chore, CustomUser, Option
 from datetime import date, datetime
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from django.conf import settings
@@ -66,6 +66,10 @@ def send_due_notifications():
     Returns:
         (str): A short summary of how many users were notified.
     """
+    option = Option.objects.filter(id=1).first()
+    if option and option.vacation_mode:
+        return "Vacation mode active; no notifications sent"
+
     now_utc = timezone.now()
 
     notified = 0

--- a/backend/api/tests/unit/test_tasks.py
+++ b/backend/api/tests/unit/test_tasks.py
@@ -135,6 +135,27 @@ def test_invalid_timezone_falls_back_to_server(db, chore, fixed_now, mocker):
 
 @pytest.mark.django_db
 @pytest.mark.unit
+def test_skips_all_when_vacation_mode_active(db, chore, fixed_now, mocker):
+    """No reminders go out while vacation mode is on, and nobody is marked."""
+    from api.models import Option, PushSubscription
+
+    Option.objects.create(vacation_mode=True, med_thresh=50, high_thresh=75)
+    send = mocker.patch("api.tasks.send_web_push", return_value=True)
+    user = _make_user("a@example.com", enabled=True, hour=8)
+    PushSubscription.objects.create(
+        user=user, endpoint="https://p/x", p256dh="k", auth="s"
+    )
+
+    result = send_due_notifications()
+
+    assert send.call_count == 0
+    user.refresh_from_db()
+    assert user.last_notified_date is None
+    assert "acation" in result
+
+
+@pytest.mark.django_db
+@pytest.mark.unit
 def test_no_due_chores_marks_notified_without_pushing(db, fixed_now, mocker):
     send = mocker.patch("api.tasks.send_web_push", return_value=True)
     user = _make_user("a@example.com", enabled=True, hour=8)


### PR DESCRIPTION
## Summary

Daily reminders should not be sent while vacation mode is on. `send_due_notifications` now returns early when the `Option` singleton has `vacation_mode` enabled — no pushes go out and no users are marked notified, so reminders resume normally once vacation ends.

This is an **explicit** guard rather than relying on the side effect that enabling vacation flips active chores to status 3 (which would make `due_today` 0). That side effect is fragile — e.g. a chore created during vacation defaults to status 0 and would otherwise count as due.

## Test plan

- [x] Vacation mode on → no `send_web_push` calls, `last_notified_date` left untouched, returns a vacation message
- [x] Vacation off (no Option / vacation_mode False) → unchanged behavior (existing tests)
- [x] 54 backend tests pass; ruff clean
- [ ] CI green
- [ ] Sandbox: enable vacation, confirm the scheduled task reports no notifications and none are delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)