### PR TITLE
fix: profile header layout, avatar preview, and overflow menu closing

### DIFF
--- a/frontend/src/components/ProfileForm.vue
+++ b/frontend/src/components/ProfileForm.vue
@@ -1,18 +1,22 @@
 <template>
   <v-card color="primary" class="mx-auto" max-width="434" rounded="0" outline>
-    <v-avatar
-      :image="formData.avatar"
-      size="80"
-      color="white"
-      tonal
-      rounded="0"
-    ></v-avatar>
-    <v-card-title>
-      {{ formData.email }}
-    </v-card-title>
-    <v-card-subtitle
-      >{{ formData.first_name }} {{ formData.last_name }}</v-card-subtitle
-    >
+    <div class="d-flex align-center pa-4">
+      <v-avatar
+        :image="avatarPreview"
+        size="80"
+        color="white"
+        rounded="0"
+        class="elevation-4 me-4"
+      ></v-avatar>
+      <div class="text-truncate">
+        <div class="text-subtitle-1 font-weight-medium text-truncate">
+          {{ formData.email }}
+        </div>
+        <div class="text-body-2">
+          {{ formData.first_name }} {{ formData.last_name }}
+        </div>
+      </div>
+    </div>
     <v-card-text class="py-0">
       <Form
         @submit="submitForm"
@@ -137,7 +141,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from "vue";
+import { ref, computed, onMounted } from "vue";
 import { Form, Field } from "vee-validate";
 import * as yup from "yup";
 import { useUserStore } from "@/stores/user";
@@ -233,6 +237,16 @@ const formData = ref({
   avatar: userstore.avatar,
   isAdmin: userstore.isAdmin,
   id: userstore.id,
+});
+
+// Live avatar preview that follows the selected gender (and child role),
+// so picking a different avatar updates the picture immediately.
+const avatarPreview = computed(() => {
+  const child = userstore.isChild;
+  if (formData.value.male) {
+    return child ? "child_male_avatar.jpg" : "adult_male_avatar.jpg";
+  }
+  return child ? "child_female_avatar.jpg" : "adult_female_avatar.jpg";
 });
 
 const submitForm = (values) => {

--- a/frontend/src/views/AppNavigation.vue
+++ b/frontend/src/views/AppNavigation.vue
@@ -67,12 +67,7 @@
       @click="themeStore.toggle()"
       variant="text"
     ></v-btn>
-    <v-menu
-      v-model="menu"
-      :close-on-content-click="false"
-      location="end"
-      v-if="store.isLoggedIn"
-    >
+    <v-menu v-model="menu" location="end" v-if="store.isLoggedIn">
       <template v-slot:activator="{ props }">
         <v-btn icon="mdi-dots-vertical" v-bind="props"></v-btn>
       </template>
@@ -94,10 +89,6 @@
             }}
           </v-list-item-title>
         </v-list-item>
-        <VacationForm
-          v-model="showVacationForm"
-          @update-dialog="updateVacationDialog"
-        />
         <v-list-item to="/profile" prepend-icon="mdi-account">
           <v-list-item-title>Profile</v-list-item-title>
         </v-list-item>
@@ -106,6 +97,11 @@
         </v-list-item>
       </v-list>
     </v-menu>
+    <VacationForm
+      v-if="store.isLoggedIn"
+      v-model="showVacationForm"
+      @update-dialog="updateVacationDialog"
+    />
   </v-app-bar>
 </template>
 


### PR DESCRIPTION
## Summary

Four UI cleanups:

1. **Overflow (⋮) menu didn't close after selecting an item.** It had `close-on-content-click="false"` because `VacationForm` was rendered *inside* the menu's list — closing the menu would have unmounted the dialog. Moved `VacationForm` out of the menu so the menu closes normally on selection and the vacation dialog still works.
2. **Profile header layout** — the avatar now sits **beside** the email/name instead of stacked above them.
3. **Avatar shadow** — added elevation so the square avatar stands out from the card.
4. **Avatar selection did nothing visible** — the header avatar was bound to a static value, so changing the gender radio didn't update it. It's now a live `computed` driven by the selected gender (and child role), so the picture updates immediately. (Saving already persisted the choice; this fixes the missing live preview.)

## Test plan

- [ ] ⋮ menu → selecting Profile/Logout/Admin closes the menu; "Enable/Disable Vacation" closes the menu and opens the vacation dialog
- [ ] Profile header shows avatar to the left of email + name, avatar has a shadow
- [ ] Picking a different avatar updates the header picture immediately; Save persists it

🤖 Generated with [Claude Code](https://claude.com/claude-code)