### PR TITLE
fix: chore list 500 when a chore has an assignee (groups resolver)

### DIFF
--- a/backend/api/tests/api/test_chore_api.py
+++ b/backend/api/tests/api/test_chore_api.py
@@ -22,6 +22,25 @@ def test_list_chores(auth_client, chore):
 
 @pytest.mark.django_db
 @pytest.mark.api
+def test_list_chores_with_assignee(auth_client, chore, user):
+    """Listing a chore that has an assignee must serialize the nested user.
+
+    Regression: the nested CustomUserSchema failed to resolve `groups` during
+    response re-validation, 500ing the chore list after a chore was claimed.
+    """
+    chore.assignee = user
+    chore.save()
+
+    response = auth_client.get("/api/v2/chores")
+    assert response.status_code == 200
+    result = next(c for c in response.json() if c["id"] == chore.id)
+    assert result["assignee"] is not None
+    assert result["assignee"]["id"] == user.id
+    assert result["assignee"]["groups"] == []
+
+
+@pytest.mark.django_db
+@pytest.mark.api
 def test_create_chore(auth_client, area):
     payload = {
         "chore_name": "New Chore",

--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -223,13 +223,22 @@ class CustomUserSchema(Schema):
         """
         Resolve the groups field to a list of group IDs.
 
+        Handles both a CustomUser model (groups is a related manager) and an
+        already-serialized value (a list of ids), so the schema survives
+        re-validation when used as a nested field (e.g. ChoreOut.assignee).
+
         Args:
             obj (CustomUser): The user instance being serialized.
 
         Returns:
             List[int]: List of group IDs the user belongs to.
         """
-        return [group.id for group in obj.groups.all()]
+        groups = getattr(obj, "groups", None)
+        if groups is None:
+            return []
+        if hasattr(groups, "all"):
+            return [group.id for group in groups.all()]
+        return list(groups)
 
 
 class AreaGroupIn(Schema):


### PR DESCRIPTION
## Summary

After claiming a chore, the chore list 500'd with:

```
pydantic_core.ValidationError: response.0.assignee.groups
  Field required [type=missing, input_value=<DjangoGetter: CustomUser...>]
```

`ChoreOut.assignee` is a nested `CustomUserSchema`, whose `resolve_groups` did `obj.groups.all()`. During ninja's **response re-validation** of the manually-built `ChoreOut`, `groups` is already a serialized list (not a related manager), so `.all()` failed and pydantic reported the field as missing. It only triggered once a chore had an assignee (i.e. right after claiming).

### Fix
Make `resolve_groups` defensive — handle a related manager (`.all()`), an already-serialized list, or a missing value. Reproduced the failure and confirmed the fix against the exact response-validation path.

### Tests
Added `test_list_chores_with_assignee` (assign a user, GET /chores, assert the nested assignee serializes). Full suite: **54 passed**.

## Test plan

- [x] Reproduced the 500 and verified the fix
- [x] 54 backend tests pass; ruff clean
- [ ] CI green
- [ ] Dev/sandbox: claim a chore → chore list loads without error and shows the assignee

🤖 Generated with [Claude Code](https://claude.com/claude-code)