### PR TITLE
ci: fix release docs deploy moving the latest alias

### DIFF
--- a/.github/workflows/deploy-docs-release.yml
+++ b/.github/workflows/deploy-docs-release.yml
@@ -3,6 +3,11 @@ name: Deploy MkDocs (Release)
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to (re)deploy and alias as latest, e.g. 1.4"
+        required: true
 
 permissions:
   contents: write
@@ -13,10 +18,10 @@ jobs:
     runs-on: self-hosted
 
     steps:
-      - name: Checkout release tag
+      - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || github.ref_name }}
           fetch-depth: 0
 
       - name: Set up Python
@@ -38,14 +43,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          VERSION=${{ github.event.release.tag_name }}
-          VERSION=${VERSION#v}
+          if [ -n "${{ github.event.release.tag_name }}" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+            VERSION="${VERSION#v}"
+            PRERELEASE="${{ github.event.release.prerelease }}"
+          else
+            VERSION="${{ github.event.inputs.version }}"
+            PRERELEASE="false"
+          fi
 
           MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
 
           mike deploy "$MAJOR_MINOR" --push --update-aliases --config-file backend/mkdocs.yml
 
-          if [[ "${{ github.event.release.prerelease }}" != "true" ]]; then
-            mike alias "$MAJOR_MINOR" latest --push --config-file backend/mkdocs.yml
+          if [[ "$PRERELEASE" != "true" ]]; then
+            mike alias "$MAJOR_MINOR" latest --push --update-aliases --config-file backend/mkdocs.yml
             mike set-default latest --push --config-file backend/mkdocs.yml
           fi


### PR DESCRIPTION
## Summary

The **Deploy MkDocs (Release)** workflow failed on the v1.4.0 release:

```
error: alias 'latest' already exists for version '1.3'
```

`mike deploy 1.4` succeeded (1.4 docs are published), but `mike alias 1.4 latest` lacked `--update-aliases`, so mike refused to move the existing `latest` alias off 1.3.

### Fix
- Add `--update-aliases` to the `mike alias` command so `latest` re-points to the new version.
- Add a `workflow_dispatch` trigger (with a `version` input) so the `latest` alias can be corrected without cutting a new release — needed to fix the current state, since re-running the failed job would reuse the old workflow file.

## Notes
- The same bug exists in **LenoreTemplate** (source of these workflows) — should be synced there too.
- After this merges, dispatch the workflow with `version=1.4` to move `latest` from 1.3 → 1.4. Future stable releases self-correct via `--update-aliases`.

## Test plan

- [ ] CI green
- [ ] Dispatch with `version=1.4` → docs `latest` points to 1.4 and is the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)