### PR TITLE
fix: Pydantic v2 500s on /areas, /chores, /historyitems (dirtiness float + null completer)

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -167,8 +167,10 @@ class Area(models.Model):
         total_chores = self.chore_set.filter(status=0).count()
 
         if total_chores > 0:
-            # Calculate the percentage if there are chores
-            percentage = total_dirtiness / total_chores
+            # Calculate the percentage if there are chores. Round to an int:
+            # the API schema (AreaOut.dirtiness) is an int, and Pydantic v2
+            # rejects floats with a fractional part.
+            percentage = round(total_dirtiness / total_chores)
         else:
             # Handle the case when there are no chores
             percentage = 0

--- a/backend/api/tests/api/test_area_api.py
+++ b/backend/api/tests/api/test_area_api.py
@@ -1,5 +1,39 @@
 import pytest
 import json
+from datetime import date, timedelta
+
+
+def _add_chore(area, name, due_offset, completed_offset, status=0):
+    from api.models import Chore
+
+    return Chore.objects.create(
+        chore_name=name,
+        area=area,
+        intervalNumber=1,
+        unit="day(s)",
+        effort=1,
+        nextDue=date.today() + timedelta(days=due_offset),
+        lastCompleted=date.today() - timedelta(days=completed_offset),
+        status=status,
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_list_areas_with_fractional_dirtiness(auth_client, area):
+    """Areas whose average dirtiness is fractional must not 500.
+
+    Regression: AreaOut.dirtiness is an int, but the model returned a raw
+    float average; Pydantic v2 rejected the fractional value.
+    """
+    # Two chores with different dirtiness so the average is fractional.
+    _add_chore(area, "A", due_offset=2, completed_offset=1)   # ~33
+    _add_chore(area, "B", due_offset=1, completed_offset=1)   # 50
+
+    response = auth_client.get("/api/v2/areas")
+    assert response.status_code == 200
+    result = next(a for a in response.json() if a["id"] == area.id)
+    assert isinstance(result["dirtiness"], int)
 
 
 @pytest.mark.django_db

--- a/backend/api/tests/api/test_chore_api.py
+++ b/backend/api/tests/api/test_chore_api.py
@@ -209,3 +209,35 @@ def test_complete_chore_weekly_interval(auth_client, area, user):
 
     weekly.refresh_from_db()
     assert weekly.nextDue == today + timedelta(weeks=1)
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_list_chores_with_deleted_completer(auth_client, chore):
+    """A history item whose completer was deleted (completed_by=None) must not
+    500 the chore list via last_three_history_items."""
+    from api.models import HistoryItem
+
+    HistoryItem.objects.create(
+        completed_date=date.today(), completed_by=None, chore=chore
+    )
+
+    response = auth_client.get("/api/v2/chores")
+    assert response.status_code == 200
+    result = next(c for c in response.json() if c["id"] == chore.id)
+    assert result["last_three_history_items"][0]["completed_by"] == "Unknown"
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_list_historyitems_with_deleted_completer(auth_client, chore):
+    """A history item with completed_by=None must serialize in /historyitems."""
+    from api.models import HistoryItem
+
+    HistoryItem.objects.create(
+        completed_date=date.today(), completed_by=None, chore=chore
+    )
+
+    response = auth_client.get("/api/v2/historyitems")
+    assert response.status_code == 200
+    assert response.json()["total_records"] >= 1

--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -531,7 +531,7 @@ class HistoryItemOut(Schema):
 
     id: int
     completed_date: date
-    completed_by: CustomUserSchema
+    completed_by: Optional[CustomUserSchema] = None
     chore: ChoreOutFull
 
 
@@ -1076,7 +1076,10 @@ def list_chores(
         last_three = []
         for item in last_three_query:
             display_name = ""
-            if item.completed_by.fullname == " ":
+            if item.completed_by is None:
+                # completed_by is SET_NULL on user delete; don't crash on it.
+                display_name = "Unknown"
+            elif item.completed_by.fullname == " ":
                 display_name = item.completed_by.email
             else:
                 display_name = item.completed_by.fullname


### PR DESCRIPTION
## Critical hotfix for 1.4.0 — two Pydantic-v2 strictness 500s

After the Django 5.2 / django-ninja 1.x (Pydantic v2) upgrade, schemas reject values the old Pydantic v1 silently coerced. This bundles both that we found:

### 1. `dirtiness` float → int (the reported crash)
`Area.dirtiness` returns `total_dirtiness / total_chores` (a **float** average) but `AreaOut.dirtiness` is `int`. Pydantic v2 rejects a float with a fractional part → **500 on `/areas` and `/chores`** (the latter via the nested area). Single-chore areas average to whole numbers, which is why tests missed it. **Fix:** round the average (matching `Chore.dirtiness`).

### 2. Deleted completer (`completed_by=None`)
`HistoryItem.completed_by` is `null=True, on_delete=SET_NULL`, but it was a non-Optional `CustomUserSchema` (`HistoryItemOut.completed_by`) and dereferenced directly (`item.completed_by.fullname`) in the `list_chores` last-three loop. **Deleting a user who completed chores would 500 both `/historyitems` and `/chores`.** **Fix:** make `completed_by` Optional and guard the loop (display "Unknown").

> Audit note: these are the only two remaining cases — the codebase has just two float-producing properties (both now rounded), and the other nullable FKs (`area`, `group`) can't be null via the UI.

### Tests
Regression tests for fractional-average areas, and for null `completed_by` on both `/chores` and `/historyitems`. Full suite **58 passed**.

### Follow-up
Mirrored to alpha in #85 so the next promotion stays consistent.

## Test plan
- [x] Repro'd both 500s; fixes return valid responses
- [x] 58 backend tests pass
- [ ] CI green → merge cuts 1.4.1 + `:latest`
- [ ] Verify `/areas`, `/chores`, `/historyitems` load on the rebuilt image

🤖 Generated with [Claude Code](https://claude.com/claude-code)