### PR TITLE
fix: pass --update-aliases when moving the latest docs alias

### DIFF
--- a/.github/workflows/deploy-docs-release.yml
+++ b/.github/workflows/deploy-docs-release.yml
@@ -46,6 +46,6 @@ jobs:
           mike deploy "$MAJOR_MINOR" --push --update-aliases --config-file backend/mkdocs.yml
 
           if [[ "${{ github.event.release.prerelease }}" != "true" ]]; then
-            mike alias "$MAJOR_MINOR" latest --push --config-file backend/mkdocs.yml
+            mike alias "$MAJOR_MINOR" latest --push --update-aliases --config-file backend/mkdocs.yml
             mike set-default latest --push --config-file backend/mkdocs.yml
           fi


### PR DESCRIPTION
## Why

`mike alias "$MAJOR_MINOR" latest --push` fails whenever `latest` already points at a different version — which is every minor-version release:

```
error: alias 'latest' already exists for version '1.3'
```

`mike deploy` on the line above already passes `--update-aliases`; the alias line was missed.

## This has already fired twice

- **LenoreShop v1.8.0** (2026-05-28) — run failed on `latest already exists for version '1.7'`. `mike deploy 1.8` had succeeded, so the versioned docs published and only the alias was left stale. **The docs site has served 1.7 as `latest` ever since — 72 days.**
- **LenoreChore v1.4.0** (2026-06-03, [run 26912157320](https://github.com/Novanglus96/LenoreChore/actions/runs/26912157320)) — identical failure on `1.3`.

LenoreShop got the flag on 2026-06-01; the fix was never propagated to the other three repos. This PR closes that gap.

## The failure shape

A job that dies between publishing a versioned artifact and moving its floating alias leaves the alias **permanently stale with no alarm** — the versioned docs look fine, and only the entry point is wrong. Making this class of partial success impossible is one of the goals of the `lenore-ci` reusable workflow; this is the cheap interim fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)