### PR TITLE
ci: move fork-PR workflows to GitHub-hosted runners

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   lint:
     if: github.repository != 'Novanglus96/LenoreTemplate'
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
         uses: amannn/action-semantic-pull-request@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,9 +7,17 @@ on:
 jobs:
   backend:
     if: github.repository != 'Novanglus96/LenoreTemplate'
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # Pinned so the hosted runner's default interpreter cannot silently
+      # change what the suite runs against. Matches the 3.11 already used by
+      # deploy-docs-release.yml in this repo.
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
 
       - name: Install dependencies
         working-directory: backend
@@ -23,7 +31,7 @@ jobs:
 
   frontend:
     if: github.repository != 'Novanglus96/LenoreTemplate'
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## The exposure

This repo is **public**, and it has **two** workflows triggered by `pull_request`, both on `runs-on: self-hosted` — the runner pool on artemis2, which mounts `/var/run/docker.sock`. For a `pull_request` event the workflow that runs comes from the merge commit, so fork-authored content is in scope.

`gh-runners/docker-compose.yml` states the assumption plainly:

> anything that runs on these runners can control docker on artemis2 … Keep the repos private and treat workflow files as trusted.

The repos are no longer private. artemis2 is also a backup client holding a confined rsync key to zeus, so runner compromise is not contained to CI.

### `tests.yml` is the sharper edge

`pr-title-lint.yml` is the one usually cited, but `tests.yml` is materially worse — it executes fork-authored code by design:

- **backend**: `pip install -r requirements-test.txt` then `pytest` — arbitrary Python from the PR.
- **frontend**: `npm install` (arbitrary `postinstall` scripts), then `docker build` and `docker run` against the PR's `frontend/` — **on a runner with the host docker socket mounted.**

That is arbitrary code execution plus docker daemon access on artemis2, from an unreviewed fork PR. The only thing in the way is a GitHub **default** ("require approval for first-time contributors"), not a deliberate control — and it does not cover a second PR from someone whose first was approved.

## The change

- `runs-on: self-hosted` → `runs-on: ubuntu-latest` in both workflows (three jobs total).
- Pin the backend job to **Python 3.11** with `actions/setup-python@v5`, matching what `deploy-docs-release.yml` already uses in this repo. Without it the suite would silently run against whatever interpreter the hosted image ships.

Docker is preinstalled on GitHub-hosted Ubuntu runners, so the frontend job's `docker build`/`docker run` works unchanged. Trusted work — release, build, publish, docs, announce — is untouched and stays on the self-hosted pool.

## Note on the commit type

Titled `ci:` deliberately so it does **not** trigger a semantic-release version bump. A `fix:` here would cut a release for a CI-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)